### PR TITLE
feat(rfcs): unified-final pass — close library/spec gaps + tier conformance fixtures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,58 @@
 
 ## Unreleased
 
+### rc.4 — RFC unified-final pass
+
+Driven by `plans/aitp-rfc-unified-final-plan.md`. Closes the gap between
+the published RFCs and the reference library, tightens four security
+surfaces, and adds machine-readable conformance metadata so v0.1 runners
+can correctly skip post-v0.1 fixtures.
+
+- **RFC-AITP-0004 §8.1.** New non-normative shortened-renewal extension
+  describing the wire format for an opt-in renewal endpoint advertised
+  via `extensions["rfc-aitp-0005.renew_uri"]`. Eventual standardization
+  reserved as **RFC-AITP-0013** (Planned).
+- **RFC-AITP-0010.** Added a top-of-file conformance-scope statement —
+  the `bundle-*` fixture set is SKIP for v0.1 runners; the RFC's
+  MUST-level normative text applies only to draft opt-in
+  implementations.
+- **RFC-AITP-0008 §3.3.** Mandates that all network-adjacent revocation
+  lookups defer until *after* signature verification; closes the
+  attacker-chosen-network-fetch class of bugs.
+- **RFC-AITP-0007 §3.2.** `soft_fail` now MUST behave as `fail_closed`
+  when no trust basis exists for an issuer. Peer-Manifest key resolution
+  is `fail_closed` regardless of mode — no safe subset for unverified
+  identity.
+- **RFC-AITP-0002 §3.2.** Pinned-key key-possession-only verification is
+  forbidden as a production default; production code paths MUST consult
+  a configured `pinned_keys` store.
+- **Conformance fixtures.** Every fixture under `schemas/conformance/`
+  carries a metadata block (`rfc`, `status`, `required_for_v0_1`,
+  `feature`). New JSON Schema
+  `schemas/json/aitp-conformance-fixture.schema.json` enforces the block;
+  CI validates every fixture against it. Bundle and multi-hop fixtures
+  are tagged `status: "draft"`; v0.1 core fixtures are tagged
+  `status: "core"`. New fixture `del-004-multihop-rejected-v01` proves
+  v0.1 implementations reject any non-empty `chain` field with
+  `DELEGATION_MULTIHOP_NOT_SUPPORTED`.
+- **Error-code registry.** Added `TCT_EXPIRES_AFTER_MANIFEST` and
+  `INCOMPATIBLE_IDENTITY_TYPE`. Every table now carries a `spec_status`
+  column (`core` or `draft`).
+- **New registry.** `registries/extension-keys.md` pins the four
+  AITP-defined Manifest extension keys (`verify_uri`, `renew_uri`,
+  `delegation_verify_uri`, `revocation_list_uri`) so independent
+  implementations don't fork the strings.
+- **RFC process.** Strengthened the KAT requirement to mandate hex
+  preimage bytes (the decode-before-hash convention is non-obvious from
+  text alone — has caused two interop bugs); explicit non-merge gate for
+  PRs introducing new signing inputs without KAT vectors.
+- **Operational guidance.** New "Shortened renewal (experimental)"
+  section in `docs/operational-guidance.md` documenting when to enable
+  the opt-in extension, the discovery key, the 24h/8-renewal full-bind
+  ceiling, and the failure-mode fallback to full handshake.
+
+---
+
 RFC improvement pass driven by `plans/aitp-rfc-improvement-plan.md`,
 followed by a deep audit pass that fixed cross-RFC contradictions, schema
 drift, and stale-Reserved wording across docs. Tightens ambiguous PoP

--- a/README.md
+++ b/README.md
@@ -162,6 +162,7 @@ There is no service-consumer profile. AITP is peer-to-peer.
 - **RFC-AITP-0010 Session Trust Bundle** *(Draft, post-v0.1)* — multi-agent session scaling.
 - **RFC-AITP-0011 Multi-hop Delegation** *(Draft, post-v0.1)* — chains beyond a single hop.
 - **RFC-AITP-0012 Extensions** *(reserved)* — `extensions.zk` and `extensions.tee` namespaces.
+- **RFC-AITP-0013 TCT Renewal Extension** *(Planned)* — standardization of the non-normative shortened renewal endpoint described in RFC-AITP-0004 §8.1.
 
 ---
 

--- a/docs/operational-guidance.md
+++ b/docs/operational-guidance.md
@@ -9,9 +9,13 @@ deployments. The authoritative protocol is in the RFCs under
 ## Handshake renewal
 
 TCTs expire. Peers that need a continuing trust relationship rerun the
-Mutual Handshake (RFC-AITP-0004) before expiry. The protocol does not
-define a shortened renewal flow — round 1 is always full credential
-exchange, and round 2 always issues fresh TCTs.
+Mutual Handshake (RFC-AITP-0004) before expiry. AITP v0.1 conformance
+defines only the **full Mutual Handshake** as a renewal mechanism —
+round 1 is full credential exchange, round 2 issues fresh TCTs, and the
+contract is uniform across initial and renewing handshakes. A
+non-normative **shortened renewal extension** is described in
+[RFC-AITP-0004 §8.1](../rfcs/RFC-AITP-0004-mutual-handshake.md#81-non-normative-shortened-renewal-extension)
+and discussed below; it is opt-in and not part of v0.1 conformance.
 
 ### Recommended pattern
 
@@ -33,13 +37,70 @@ exchange, and round 2 always issues fresh TCTs.
   Manifest with a newer `published_at`. The renewing peer MUST accept
   the newer Manifest and discard its cached copy (RFC-AITP-0004 §11.3).
 
-### Why no in-band renewal?
+### Why no in-band renewal in v0.1 conformance?
 
 A shortened "renewal" message that skipped credential exchange would
 re-introduce the trust gap: an attacker holding an expired TCT could
 present it as proof of an existing relationship and skip identity
 verification. Forcing every renewal through the full handshake keeps the
 contract uniform: every TCT is issued only after a fresh PoP exchange.
+
+### Shortened renewal (experimental)
+
+[RFC-AITP-0004 §8.1](../rfcs/RFC-AITP-0004-mutual-handshake.md#81-non-normative-shortened-renewal-extension)
+defines a non-normative, opt-in shortened renewal endpoint that some
+implementations (notably the reference library `aitp-rs`) offer behind
+an explicit feature flag. It is **not** part of v0.1 conformance and is
+not assumed by interoperating peers unless advertised.
+
+**When you might enable it.** High-frequency, low-value renewals between
+two long-lived peers under the same operator (e.g. internal services
+that handshake hundreds of times per minute) where the full
+four-message handshake adds measurable latency and the operator accepts
+the narrower trust-rebinding semantics described below.
+
+**Discovery.** A peer that supports shortened renewal advertises it in
+its Manifest:
+
+```json
+{
+  "extensions": {
+    "rfc-aitp-0005.renew_uri": "https://agent-b.example.com/aitp/handshake/renew"
+  }
+}
+```
+
+The key is registered in
+[`registries/extension-keys.md`](../registries/extension-keys.md). Peers
+without that extension key MUST fall back to a full Mutual Handshake.
+
+**Wire format and constraints.** See RFC-AITP-0004 §8.1 for the request
+/ response shape. Operationally:
+
+- The current TCT MUST still be valid (`expires_at > now`) when the
+  renewal request is sent. Shortened renewal cannot resurrect an
+  already-expired TCT — that path requires a full handshake.
+- The issuer MUST re-evaluate its grant policy, revocation list, and
+  Manifest expiry on every shortened renewal. Skipping identity
+  re-presentation is not a license to skip authorization.
+- Implementations SHOULD impose a "ceiling" on consecutive shortened
+  renewals (e.g. force a full handshake every N renewals or every M
+  hours of wall-clock continuity) so that long-lived sessions
+  periodically re-bind identity end-to-end. The reference default is
+  every **24 hours** or every **8 shortened renewals**, whichever comes
+  first.
+
+**Failure modes.** A shortened renewal MAY fail with any of the standard
+handshake error codes plus the new
+[`TCT_EXPIRES_AFTER_MANIFEST`](../registries/error-codes.md) when the
+issuer's Manifest has rotated below the requested new expiry. On any
+failure the renewing peer MUST fall back to a full Mutual Handshake
+before continuing to use the (still-valid-but-soon-expiring) TCT.
+
+**Backwards compatibility.** A peer that does not advertise
+`rfc-aitp-0005.renew_uri` MUST be renewed via full Mutual Handshake. A
+peer that advertises it MAY also accept full Mutual Handshakes — the
+extension is additive, never substitutive.
 
 ---
 

--- a/governance/RFC-PROCESS.md
+++ b/governance/RFC-PROCESS.md
@@ -97,17 +97,24 @@ What does NOT require an RFC:
 
 ### KAT requirement
 
-Any RFC that introduces a new signing input, hash construction, or
-canonicalization step MUST include at least one known-answer test
-(KAT) vector. The vector MUST pin:
+Any RFC that introduces a new **signing input, hash construction,
+canonicalization step, or PoP pattern** MUST include at least one
+known-answer test (KAT) vector. The vector MUST pin:
 
-- A pinned preimage (using one of the pinned keypairs in
-  [`schemas/conformance/known-answer/keypairs.json`](../schemas/conformance/known-answer/keypairs.json)
-  where applicable).
-- The hex of the SHA-256 digest (or other hash output if the RFC
+- The **preimage bytes in hex** (not just a description of how to
+  construct them). When the construction is `sha256(base64url_decode(x))`
+  — the convention used by every PoP site in v0.1 (see
+  [RFC-AITP-0001 §5.4.2](../rfcs/RFC-AITP-0001-core.md)) — the preimage
+  bytes are the *decoded* bytes, not the ASCII bytes of the base64url
+  string. Publishing the preimage as hex eliminates the ambiguity that
+  caused the alpha.4 PoP-nonce bug and the beta.1 Manifest-PoP bug.
+- The **SHA-256 digest in hex** (or other hash output if the RFC
   introduces a new hash).
-- The base64url-encoded signature, if the construction terminates in
-  a signature.
+- The **base64url-encoded Ed25519 signature** under `kat-keypair-001`
+  from [`schemas/conformance/known-answer/keypairs.json`](../schemas/conformance/known-answer/keypairs.json),
+  if the construction terminates in a signature. RFCs that need a
+  different keypair MAY use any pinned keypair from that file but MUST
+  cite which one in the KAT entry.
 
 KAT vectors live in
 [`schemas/conformance/known-answer/jcs-sha256.json`](../schemas/conformance/known-answer/jcs-sha256.json)
@@ -124,6 +131,16 @@ A KAT is not required for RFCs that only adjust process, governance,
 documentation, or non-normative narrative text. It IS required for
 any RFC that lands in `rfcs/RFC-AITP-*.md` and changes what bytes are
 fed to a signing or hashing primitive.
+
+**Enforcement.** PRs that introduce a new signing input, hash
+construction, or PoP pattern without a corresponding KAT vector will
+not be merged. This rule exists because the decode-before-hash
+convention (`sha256(base64url_decode(x))`) is non-obvious from the
+spec text alone and has caused two cross-implementation interop bugs
+in v0.1 (handshake PoP nonce; Manifest PoP challenge). Reviewers
+SHOULD reject any normative addition to a signing surface whose KAT
+vector is missing or specifies the preimage in any encoding other
+than hex.
 
 **Draft-stage carve-out.** Draft RFCs (status `Draft` and not yet
 RC) MAY publish without a KAT vector if the RFC explicitly notes the

--- a/registries/README.md
+++ b/registries/README.md
@@ -7,6 +7,7 @@ This directory tracks the well-known identifiers used in AITP. Each registry is 
 | Identity types | [identity-types.md](identity-types.md) | [RFC-AITP-0002](../rfcs/RFC-AITP-0002-identity.md) |
 | Capabilities | [capabilities.md](capabilities.md) | [RFC-AITP-0001](../rfcs/RFC-AITP-0001-core.md), [RFC-AITP-0005](../rfcs/RFC-AITP-0005-tct.md) |
 | Error codes | [error-codes.md](error-codes.md) | [RFC-AITP-0001](../rfcs/RFC-AITP-0001-core.md) |
+| Extension keys | [extension-keys.md](extension-keys.md) | [RFC-AITP-0001 §7](../rfcs/RFC-AITP-0001-core.md#7-compatibility-model), [RFC-AITP-0003](../rfcs/RFC-AITP-0003-manifest.md) |
 | Media types | [media-types.md](media-types.md) | [RFC-AITP-0001](../rfcs/RFC-AITP-0001-core.md) |
 
 ## Status values

--- a/registries/error-codes.md
+++ b/registries/error-codes.md
@@ -4,6 +4,8 @@ AITP error codes returned in error envelopes (`AitpError.code`). v0.1 is JSON-on
 
 > **Stability:** The codes listed below are stable for v0.1. Implementations MUST treat unknown codes as opaque failures and MUST NOT key behavior off codes that are not in this registry. New codes can be added without an RFC; renaming or removing an existing code is a breaking change and requires the RFC process.
 
+> **`spec_status` column.** Each code below carries a `spec_status` of either `core` or `draft`. `core` codes are part of v0.1 conformance and MAY be emitted by any conformant implementation. `draft` codes are reserved for post-v0.1 RFCs (currently RFC-AITP-0010 Session Trust Bundle and RFC-AITP-0011 Multi-hop Delegation) and MUST NOT be used by v0.1 implementations except when implementing the cited draft RFC. v0.1 conformance runners MUST treat receipt of a `draft` code from an implementation that does not opt into the corresponding draft as a non-conformance.
+
 ## Code naming convention
 
 Object-level failures use the `<OBJECT>_<FAILURE>` form (e.g.
@@ -16,116 +18,120 @@ follow this convention.
 
 ## Envelope-level codes
 
-| Code | Meaning | Retryable | Spec |
-|---|---|---|---|
-| `INVALID_ENVELOPE` | Envelope failed schema validation. | false | [RFC-AITP-0001 §5.6](../rfcs/RFC-AITP-0001-core.md#56-error-envelope) |
-| `INVALID_SIGNATURE` | Signature verification failed. | false | [RFC-AITP-0001 §5.4](../rfcs/RFC-AITP-0001-core.md#54-signature) |
-| `REPLAY_DETECTED` | Duplicate `message_id`. | false | [RFC-AITP-0001 §5.5](../rfcs/RFC-AITP-0001-core.md#55-replay-protection) |
-| `TIMESTAMP_EXPIRED` | Timestamp outside tolerance. | true | [RFC-AITP-0001 §5.5](../rfcs/RFC-AITP-0001-core.md#55-replay-protection) |
-| `UNKNOWN_VERSION` | Unsupported `version` field. | false | [RFC-AITP-0001 §7](../rfcs/RFC-AITP-0001-core.md#7-compatibility-model) |
-| `IDENTITY_FAILED` | Identity binding could not be verified. | false | [RFC-AITP-0002](../rfcs/RFC-AITP-0002-identity.md) |
-| `POLICY_VIOLATION` | Requested capability not granted. | false | [RFC-AITP-0004 §4](../rfcs/RFC-AITP-0004-mutual-handshake.md#4-tct-issuance-rules) |
-| `GRANT_OVERFLOW` | Peer-issued TCT grants exceed `offered_capabilities`. | false | [RFC-AITP-0004](../rfcs/RFC-AITP-0004-mutual-handshake.md) |
-| `INSUFFICIENT_GRANTS` | Received peer-issued TCT lacks a capability listed in the receiver's own `required_peer_capabilities`. | false | [RFC-AITP-0004 §5.3/§5.4](../rfcs/RFC-AITP-0004-mutual-handshake.md) |
-| `KEY_RESOLUTION_FAILED` | Could not resolve issuer or peer keys. | true | [RFC-AITP-0007](../rfcs/RFC-AITP-0007-key-resolution.md) |
+| Code | Meaning | Retryable | spec_status | Spec |
+|---|---|---|---|---|
+| `INVALID_ENVELOPE` | Envelope failed schema validation. | false | core | [RFC-AITP-0001 §5.6](../rfcs/RFC-AITP-0001-core.md#56-error-envelope) |
+| `INVALID_SIGNATURE` | Signature verification failed. | false | core | [RFC-AITP-0001 §5.4](../rfcs/RFC-AITP-0001-core.md#54-signature) |
+| `REPLAY_DETECTED` | Duplicate `message_id`. | false | core | [RFC-AITP-0001 §5.5](../rfcs/RFC-AITP-0001-core.md#55-replay-protection) |
+| `TIMESTAMP_EXPIRED` | Timestamp outside tolerance. | true | core | [RFC-AITP-0001 §5.5](../rfcs/RFC-AITP-0001-core.md#55-replay-protection) |
+| `UNKNOWN_VERSION` | Unsupported `version` field. | false | core | [RFC-AITP-0001 §7](../rfcs/RFC-AITP-0001-core.md#7-compatibility-model) |
+| `IDENTITY_FAILED` | Identity binding could not be verified. | false | core | [RFC-AITP-0002](../rfcs/RFC-AITP-0002-identity.md) |
+| `POLICY_VIOLATION` | Requested capability not granted. | false | core | [RFC-AITP-0004 §4](../rfcs/RFC-AITP-0004-mutual-handshake.md#4-tct-issuance-rules) |
+| `GRANT_OVERFLOW` | Peer-issued TCT grants exceed `offered_capabilities`. | false | core | [RFC-AITP-0004](../rfcs/RFC-AITP-0004-mutual-handshake.md) |
+| `INSUFFICIENT_GRANTS` | Received peer-issued TCT lacks a capability listed in the receiver's own `required_peer_capabilities`. | false | core | [RFC-AITP-0004 §5.3/§5.4](../rfcs/RFC-AITP-0004-mutual-handshake.md) |
+| `KEY_RESOLUTION_FAILED` | Could not resolve issuer or peer keys. | true | core | [RFC-AITP-0007](../rfcs/RFC-AITP-0007-key-resolution.md) |
 
 ## TCT-verification codes (RFC-AITP-0005)
 
 Returned when a peer evaluates a TCT outside the handshake context — e.g. via a TCT verification API or local verification of a presented TCT.
 
-| Code | Meaning | Retryable |
-|---|---|---|
-| `TCT_EXPIRED` | TCT `expires_at` is in the past. | false |
-| `TCT_REVOKED` | TCT `jti` is in the issuing peer's deny list. | false |
-| `TCT_SIGNATURE_INVALID` | TCT signature does not validate under the issuing peer's key. | false |
+| Code | Meaning | Retryable | spec_status |
+|---|---|---|---|
+| `TCT_EXPIRED` | TCT `expires_at` is in the past. | false | core |
+| `TCT_REVOKED` | TCT `jti` is in the issuing peer's deny list. | false | core |
+| `TCT_SIGNATURE_INVALID` | TCT signature does not validate under the issuing peer's key. | false | core |
+| `TCT_EXPIRES_AFTER_MANIFEST` | TCT `expires_at` exceeds the issuing peer's Manifest `expires_at` (RFC-AITP-0004 §4.3). The peer-issued TCT cannot outlive the credential that authenticates its issuer's key. | false | core |
 
 ## Downstream PoP codes (RFC-AITP-0005 §6)
 
-| Code | Meaning | Retryable |
-|---|---|---|
-| `POP_CHALLENGE_INVALID` | Challenge envelope was malformed or stale. | false |
-| `POP_RESPONSE_INVALID` | Response signature failed verification against `binding.cnf`. | false |
+| Code | Meaning | Retryable | spec_status |
+|---|---|---|---|
+| `POP_CHALLENGE_INVALID` | Challenge envelope was malformed or stale. | false | core |
+| `POP_RESPONSE_INVALID` | Response signature failed verification against `binding.cnf`. | false | core |
 
 ## Manifest codes (RFC-AITP-0003)
 
-| Code | Meaning | Retryable |
-|---|---|---|
-| `MANIFEST_EXPIRED` | `expires_at` is in the past. | false |
-| `MANIFEST_SIGNATURE_INVALID` | Signature verification failed. | false |
-| `MANIFEST_POP_FAILED` | Proof-of-possession verification failed. | false |
-| `INCOMPATIBLE_TRUST_ANCHORS` | No overlap in accepted trust anchors. | false |
-| `MANIFEST_VERSION_UNKNOWN` | `version` not supported by this implementation. | false |
+| Code | Meaning | Retryable | spec_status |
+|---|---|---|---|
+| `MANIFEST_EXPIRED` | `expires_at` is in the past. | false | core |
+| `MANIFEST_SIGNATURE_INVALID` | Signature verification failed. | false | core |
+| `MANIFEST_POP_FAILED` | Proof-of-possession verification failed. | false | core |
+| `INCOMPATIBLE_TRUST_ANCHORS` | No overlap in accepted trust anchors. | false | core |
+| `INCOMPATIBLE_IDENTITY_TYPE` | Peer's `identity.type` is not present in the receiver's `accepted_identity_types`. More specific than `INCOMPATIBLE_TRUST_ANCHORS`: signals identity-type incompatibility (e.g. `pinned_key` vs. `oidc`) rather than trust-anchor incompatibility. | false | core |
+| `MANIFEST_VERSION_UNKNOWN` | `version` not supported by this implementation. | false | core |
 
 ## Mutual Handshake codes (RFC-AITP-0004)
 
 Returned in error envelopes during the four-message handshake.
 
-| Code | Meaning |
-|---|---|
-| `INCOMPATIBLE_TRUST_ANCHORS` | No trust-anchor overlap. |
-| `MANIFEST_SIGNATURE_INVALID` | Peer's Manifest signature invalid. |
-| `MANIFEST_POP_FAILED` | Peer's Manifest PoP failed. |
-| `POP_VERIFICATION_FAILED` | Round-2 PoP signature failed. |
-| `NONCE_MISMATCH` | `pop_nonce_echo` mismatch. |
-| `AUDIENCE_MISMATCH` | TCT audience ≠ self AID. |
-| `GRANT_OVERFLOW` | TCT grants exceed peer's `offered_capabilities`. |
-| `TCT_EXPIRED` | TCT already expired. |
-| `IDENTITY_FAILED` | Peer identity verification failed. |
-| `REPLAY_DETECTED` | Duplicate `message_id`. |
-| `TIMESTAMP_EXPIRED` | Envelope timestamp outside tolerance. |
+| Code | Meaning | spec_status |
+|---|---|---|
+| `INCOMPATIBLE_TRUST_ANCHORS` | No trust-anchor overlap. | core |
+| `INCOMPATIBLE_IDENTITY_TYPE` | Peer's identity type not in `accepted_identity_types`. | core |
+| `MANIFEST_SIGNATURE_INVALID` | Peer's Manifest signature invalid. | core |
+| `MANIFEST_POP_FAILED` | Peer's Manifest PoP failed. | core |
+| `POP_VERIFICATION_FAILED` | Round-2 PoP signature failed. | core |
+| `NONCE_MISMATCH` | `pop_nonce_echo` mismatch. | core |
+| `AUDIENCE_MISMATCH` | TCT audience ≠ self AID. | core |
+| `GRANT_OVERFLOW` | TCT grants exceed peer's `offered_capabilities`. | core |
+| `TCT_EXPIRED` | TCT already expired. | core |
+| `TCT_EXPIRES_AFTER_MANIFEST` | TCT `expires_at` exceeds issuer's Manifest `expires_at`. | core |
+| `IDENTITY_FAILED` | Peer identity verification failed. | core |
+| `REPLAY_DETECTED` | Duplicate `message_id`. | core |
+| `TIMESTAMP_EXPIRED` | Envelope timestamp outside tolerance. | core |
 
 ## Manifest-service codes
 
 Returned by an HTTP endpoint serving `/.well-known/aitp-manifest` or by an out-of-band manifest lookup.
 
-| Code | Meaning |
-|---|---|
-| `MANIFEST_EXPIRED` | `expires_at` in the past. |
-| `MANIFEST_SIGNATURE_INVALID` | Signature verification failed. |
-| `MANIFEST_POP_FAILED` | Proof-of-possession failed. |
-| `MANIFEST_VERSION_UNKNOWN` | Version not supported. |
-| `MANIFEST_NOT_FOUND` | No manifest for the requested AID. |
+| Code | Meaning | spec_status |
+|---|---|---|
+| `MANIFEST_EXPIRED` | `expires_at` in the past. | core |
+| `MANIFEST_SIGNATURE_INVALID` | Signature verification failed. | core |
+| `MANIFEST_POP_FAILED` | Proof-of-possession failed. | core |
+| `MANIFEST_VERSION_UNKNOWN` | Version not supported. | core |
+| `MANIFEST_NOT_FOUND` | No manifest for the requested AID. | core |
 
 ## Delegation codes (RFC-AITP-0006)
 
 Delegation-layer codes carry the `DELEGATION_` prefix so they cannot be confused with the envelope-level or manifest-level codes that share the same root.
 
-| Code | Meaning |
-|---|---|
-| `DELEGATION_AUDIENCE_MISMATCH` | `audience ≠ issuer_aid`. |
-| `DELEGATION_SCOPE_EXCEEDED` | `scope ⊄ grant_proof.capabilities`. |
-| `DELEGATION_INVALID_GRANT_PROOF` | `grant_proof.signature` invalid, or `grant_proof.subject ≠ issued_by`. |
-| `DELEGATION_SOURCE_TCT_REVOKED` | `grant_proof.source_tct_jti` is in the issuing peer's deny list. |
-| `DELEGATION_INVALID_SIGNATURE` | `delegation.signature` invalid. |
-| `DELEGATION_EXPIRED` | Token or grant proof expired. |
-| `DELEGATION_POP_FAILED` | Proof-of-possession failed. |
-| `DELEGATION_MULTIHOP_NOT_SUPPORTED` | Multi-hop attempt detected (v0.1 implementations reject multi-hop tokens). |
+| Code | Meaning | spec_status |
+|---|---|---|
+| `DELEGATION_AUDIENCE_MISMATCH` | `audience ≠ issuer_aid`. | core |
+| `DELEGATION_SCOPE_EXCEEDED` | `scope ⊄ grant_proof.capabilities`. | core |
+| `DELEGATION_INVALID_GRANT_PROOF` | `grant_proof.signature` invalid, or `grant_proof.subject ≠ issued_by`. | core |
+| `DELEGATION_SOURCE_TCT_REVOKED` | `grant_proof.source_tct_jti` is in the issuing peer's deny list. | core |
+| `DELEGATION_INVALID_SIGNATURE` | `delegation.signature` invalid. | core |
+| `DELEGATION_EXPIRED` | Token or grant proof expired. | core |
+| `DELEGATION_POP_FAILED` | Proof-of-possession failed. | core |
+| `DELEGATION_MULTIHOP_NOT_SUPPORTED` | Multi-hop attempt detected (v0.1 implementations reject multi-hop tokens). | core |
 
 ## Multi-hop delegation codes (RFC-AITP-0011, post-v0.1)
 
 These codes are reserved for v0.2 multi-hop delegation (RFC-AITP-0011 is currently Draft and not part of v0.1 conformance). Implementations targeting only v0.1 will not emit them.
 
-| Code | Meaning |
-|---|---|
-| `DELEGATION_HOP_LIMIT_EXCEEDED` | Chain length exceeds `max_delegation_hops` (default 3). |
-| `DELEGATION_CHAIN_HASH_MISMATCH` | `chain_hash` does not match the `chain` array contents (truncation or tampering detected). |
+| Code | Meaning | spec_status |
+|---|---|---|
+| `DELEGATION_HOP_LIMIT_EXCEEDED` | Chain length exceeds `max_delegation_hops` (default 3). | draft |
+| `DELEGATION_CHAIN_HASH_MISMATCH` | `chain_hash` does not match the `chain` array contents (truncation or tampering detected). | draft |
 
 ## Session Trust Bundle codes (RFC-AITP-0010, post-v0.1)
 
 These codes are reserved for v0.2 Session Trust Bundles (RFC-AITP-0010 is currently Draft and not part of v0.1 conformance). The granular code set was pinned to align with the `aitp-rs` adapter that emits them ahead of v0.2 conformance.
 
-| Code | Meaning |
-|---|---|
-| `BUNDLE_INVALID_SIGNATURE` | Coordinator's outer bundle signature failed verification under the coordinator's Manifest key. |
-| `BUNDLE_VERSION_MISMATCH` | `version` is not `"aitp/0.1"` (or a later version this implementation supports). |
-| `BUNDLE_EXPIRED` | `expires_at` is in the past at verification time. |
-| `BUNDLE_EXPIRY_WINDOW_INVARIANT` | `expires_at` is greater than `min(participants[*].tct.expires_at)` (violates RFC-AITP-0010 §6). |
-| `BUNDLE_COORDINATOR_ISSUER_MISMATCH` | One or more `participants[*].tct.issuer` values do not equal `coordinator`. |
-| `BUNDLE_AUDIENCE_MISMATCH` | A `participants[i].tct.audience` does not equal `participants[i].aid`. |
-| `BUNDLE_EMPTY_PARTICIPANTS` | `participants` array is empty. |
-| `BUNDLE_PARTICIPANT_TCT_INVALID` | At least one embedded participant TCT failed standard TCT verification. |
-| `BUNDLE_NOT_MEMBER` | Receiver's AID is not in `participants[*].aid`. |
-| `SESSION_BUNDLE_INVALID` | Aggregate fallback — implementations MAY return this when a deployment policy requires a single-error surface for bundles, in lieu of the specific codes above. |
+| Code | Meaning | spec_status |
+|---|---|---|
+| `BUNDLE_INVALID_SIGNATURE` | Coordinator's outer bundle signature failed verification under the coordinator's Manifest key. | draft |
+| `BUNDLE_VERSION_MISMATCH` | `version` is not `"aitp/0.1"` (or a later version this implementation supports). | draft |
+| `BUNDLE_EXPIRED` | `expires_at` is in the past at verification time. | draft |
+| `BUNDLE_EXPIRY_WINDOW_INVARIANT` | `expires_at` is greater than `min(participants[*].tct.expires_at)` (violates RFC-AITP-0010 §6). | draft |
+| `BUNDLE_COORDINATOR_ISSUER_MISMATCH` | One or more `participants[*].tct.issuer` values do not equal `coordinator`. | draft |
+| `BUNDLE_AUDIENCE_MISMATCH` | A `participants[i].tct.audience` does not equal `participants[i].aid`. | draft |
+| `BUNDLE_EMPTY_PARTICIPANTS` | `participants` array is empty. | draft |
+| `BUNDLE_PARTICIPANT_TCT_INVALID` | At least one embedded participant TCT failed standard TCT verification. | draft |
+| `BUNDLE_NOT_MEMBER` | Receiver's AID is not in `participants[*].aid`. | draft |
+| `SESSION_BUNDLE_INVALID` | Aggregate fallback — implementations MAY return this when a deployment policy requires a single-error surface for bundles, in lieu of the specific codes above. | draft |
 
 ## Adding a code
 

--- a/registries/extension-keys.md
+++ b/registries/extension-keys.md
@@ -1,0 +1,41 @@
+# Extension Key Registry
+
+The Manifest (`extensions` object) and other AITP wire artifacts permit
+agents to advertise non-normative capabilities or out-of-band endpoints
+without colliding with normative fields. This registry pins the keys
+that AITP-defined extensions use, so independent implementations
+discover each other's optional features without ad-hoc string matching.
+
+| Key | Object | Type | RFC | Status |
+|---|---|---|---|---|
+| `rfc-aitp-0005.verify_uri` | Manifest `extensions` | HTTPS URL | [RFC-AITP-0005](../rfcs/RFC-AITP-0005-tct.md) | Provisional |
+| `rfc-aitp-0005.renew_uri` | Manifest `extensions` | HTTPS URL | [RFC-AITP-0004 §8.1](../rfcs/RFC-AITP-0004-mutual-handshake.md#81-non-normative-shortened-renewal-extension) (non-normative; eventual standardization reserved as RFC-AITP-0013) | Provisional |
+| `rfc-aitp-0006.delegation_verify_uri` | Manifest `extensions` | HTTPS URL | [RFC-AITP-0006](../rfcs/RFC-AITP-0006-delegation.md) | Provisional |
+| `rfc-aitp-0008.revocation_list_uri` | Manifest `extensions` | HTTPS URL | [RFC-AITP-0008](../rfcs/RFC-AITP-0008-revocation.md) | Provisional |
+
+## Rules
+
+- All values MUST be HTTPS URLs except in localhost development mode
+  (`http://localhost*` or `http://127.0.0.1*`), where deployments MAY
+  use plain HTTP for testing.
+- Extension keys MUST follow the `rfc-aitp-NNNN.<short_name>` form when
+  they are introduced by an AITP RFC. Keys outside that namespace SHOULD
+  use vendor-prefixed reverse-domain names (e.g. `com.example.feature`,
+  per [README.md naming conventions](README.md#naming-conventions)).
+- Unknown extension keys MUST be ignored by consumers
+  ([RFC-AITP-0001 §7](../rfcs/RFC-AITP-0001-core.md#7-compatibility-model)).
+  Treating an unknown key as a hard failure is non-conformant.
+- An extension key being present in this registry does NOT make the
+  underlying extension part of v0.1 conformance. The cited RFC controls
+  conformance scope.
+
+## Adding a key
+
+Open a PR adding a row above. Include:
+
+- the key string,
+- which wire object hosts it,
+- the value type (URL, integer, JSON object, etc.),
+- the RFC or document that defines its semantics,
+- the [status](README.md#status-values) (`Proposed`, `Provisional`,
+  `Stable`, or `Deprecated`).

--- a/rfcs/README.md
+++ b/rfcs/README.md
@@ -16,6 +16,7 @@ This directory contains the normative RFCs that define the Agent Identity & Trus
 | [RFC-AITP-0010](RFC-AITP-0010-session-trust-bundle.md) | Session Trust Bundle | Draft (post-v0.1) |
 | [RFC-AITP-0011](RFC-AITP-0011-multihop-delegation.md) | Multi-hop Delegation | Draft (post-v0.1) |
 | [RFC-AITP-0012](RFC-AITP-0012-extensions.md) | Extensions (ZK, TEE) — reserved | Reserved |
+| RFC-AITP-0013 | TCT Renewal Extension | Planned |
 
 ## Reading order
 
@@ -39,6 +40,12 @@ Post-v0.1 (Draft normative text published, NOT part of v0.1 conformance):
 Reserved (no normative text, numbering pinned for future work):
 
 - **[RFC-AITP-0012 Extensions](RFC-AITP-0012-extensions.md)** — ZK and TEE namespaces.
+
+Planned (RFC number reserved, no document yet):
+
+- **RFC-AITP-0013 TCT Renewal Extension** — standardization of the
+  shortened renewal endpoint described non-normatively in
+  [RFC-AITP-0004 §8.1](RFC-AITP-0004-mutual-handshake.md#81-non-normative-shortened-renewal-extension).
 
 ## RFC lifecycle
 

--- a/rfcs/RFC-AITP-0002-identity.md
+++ b/rfcs/RFC-AITP-0002-identity.md
@@ -169,6 +169,31 @@ A peer verifying an identity binding MUST:
 
 Peers MUST NOT accept pinned-key identities for public keys not present in the local configuration.
 
+#### Production requirement
+
+Verifying that a peer's key "matches its AID" — i.e. *key-possession proof
+alone* — is **not** sufficient for production deployments. AID
+construction is deterministic from the public key (RFC-AITP-0001 §5.3),
+so any agent can construct an AID for any key it generates. The trust
+anchor is the **local pinned-key configuration**, not the AID
+derivation; possession of a key tells you only that the holder generated
+that AID, not that the AID is one you have ever decided to trust.
+
+Implementations MUST NOT offer key-possession-only verification (i.e.
+"accept any pinned-key identity whose proof signature validates against
+the public key embedded in `manifest.aid`") as a production default. It
+MAY be offered as an explicitly named development mode (e.g.
+`unsafe_no_trust_store`) that:
+
+- requires explicit, non-default opt-in,
+- logs a high-severity warning each time a key is accepted, and
+- is documented as unsafe for any non-development deployment.
+
+All production code paths MUST consult a configured `pinned_keys` store
+and reject any pinned-key identity whose `public_key` is not present in
+that store, regardless of how cryptographically sound the proof
+signature is.
+
 ### 3.3 Example
 
 The `public_key` MUST be the same 43-char unpadded-base64url AID-identifier form defined in RFC-AITP-0001 §5.3. SPKI-DER and PEM forms are not permitted.

--- a/rfcs/RFC-AITP-0004-mutual-handshake.md
+++ b/rfcs/RFC-AITP-0004-mutual-handshake.md
@@ -472,6 +472,40 @@ Agents MUST NOT persist `pop_nonce` values across restarts. Restarting agents MU
 
 TCTs expire per `expires_at`. Peers MAY initiate a fresh Mutual Handshake before expiry to renew trust. There is no in-band renewal message in v0.1. Agents MUST NOT use an expired peer TCT. See [`docs/operational-guidance.md`](../docs/operational-guidance.md) for non-normative renewal patterns.
 
+### 8.1 Non-normative: shortened renewal extension
+
+Implementations MAY offer a shortened renewal endpoint as a non-normative
+extension. Shortened renewal is NOT part of v0.1 conformance and MUST be
+gated behind an explicit feature or configuration opt-in. Peers MUST
+advertise support via the `extensions["rfc-aitp-0005.renew_uri"]`
+Manifest field (see [`registries/extension-keys.md`](../registries/extension-keys.md))
+so other implementations can discover it without assuming its presence.
+
+Wire format for the experimental shortened renewal:
+
+- `POST /aitp/handshake/renew` (or any endpoint advertised in the Manifest
+  via `extensions["rfc-aitp-0005.renew_uri"]`).
+- Request body:
+  ```json
+  {
+    "current_tct": { "tct": { "...": "TctEnvelope" } },
+    "pop_nonce": "<22-char unpadded base64url>",
+    "pop_signature": "<86-char unpadded base64url, sign(holder_key, sha256(base64url_decode(pop_nonce)))>"
+  }
+  ```
+- Response: a `TctEnvelope` with a new `jti` and `expires_at ≤ issuer.manifest.expires_at`.
+
+An expired TCT MUST NOT be used to bootstrap a shortened renewal — the
+issuer MUST verify `current_tct.expires_at > now` before issuing a
+replacement. The issuer MUST also re-evaluate its grant policy for the
+holder; shortened renewal is not a bypass for revocation, manifest
+rotation, or trust-anchor changes.
+
+v0.1 conformance testers MUST NOT require shortened renewal support and
+MUST NOT fail implementations that only support full Mutual Handshake
+renewal. The eventual standardization of this extension is reserved as
+[RFC-AITP-0013 TCT Renewal Extension](README.md) (Planned).
+
 ---
 
 ## 9. Integration with Multi-Agent Sessions

--- a/rfcs/RFC-AITP-0007-key-resolution.md
+++ b/rfcs/RFC-AITP-0007-key-resolution.md
@@ -129,6 +129,36 @@ In `soft_fail`, when key resolution fails, the agent MUST restrict grants to exc
 
 For peer-key resolution failures, `soft_fail` is not applicable. Without a peer's Manifest there is nothing to verify against; the handshake cannot proceed.
 
+### 3.2 Soft-fail and identity verification
+
+`soft_fail` applies only to **grant issuance policy** *after* the
+counterparty's identity has been independently verified via at least one
+of:
+
+- a **cached, still-valid issuer key** from a prior successful fetch,
+- a **pinned issuer key** from the local trust store, or
+- a **deployment-local trust context** (e.g. a sidecar that has already
+  authenticated the issuer out-of-band).
+
+If none of these trust bases exist for the issuer in question, `soft_fail`
+MUST behave as `fail_closed`. **An unverified identity proof MUST NOT be
+accepted under any fail mode.** The safe-subset semantics in §3.1 govern
+which grants survive soft-fail; they do NOT relax the identity check
+itself.
+
+For **peer Manifest key resolution** specifically (i.e. the peer-key flow
+in §1, not the identity-issuer flow in §2), every `fail_mode` behaves as
+`fail_closed`: if the peer's Manifest cannot be fetched and verified,
+the handshake MUST fail regardless of the configured mode. There is no
+safe subset when the peer's identity cannot be verified at all — soft-fail
+is a degraded-but-still-authenticated state, not an unauthenticated one.
+
+**Security rationale.** Treating "no trust basis" as soft-fail-allowed
+collapses the distinction between *not knowing* an issuer and *trusting
+it to issue restricted grants*. An attacker who can prevent a verifier
+from reaching any of the issuer-key sources could otherwise present
+arbitrary identity proofs and be granted the safe subset by default.
+
 ---
 
 ## 4. Offline Mode

--- a/rfcs/RFC-AITP-0008-revocation.md
+++ b/rfcs/RFC-AITP-0008-revocation.md
@@ -133,6 +133,33 @@ The schema default for `revocation_policy.mode` is **`fail_closed`** (see `aitp-
 
 `max_staleness_secs` defines the maximum age of a cached revocation list. If the cached list is older than this value and the endpoint is unreachable, the configured `mode` applies.
 
+### 3.3 Revocation lookup ordering
+
+Implementations MUST verify the TCT's signature, issuer key binding,
+audience, and `expires_at` **before** consulting any network revocation
+source. The TCT fields `issuer` and `jti` are used as lookup keys for the
+deny list; verifying the signature first ensures these fields are
+authenticated and cannot be forged by an attacker to trigger
+attacker-chosen network fetches.
+
+A purely local, side-effect-free revocation check (e.g. an in-memory
+deny list with no network I/O, no DNS resolution, and no cache write)
+MAY run before signature verification, since it cannot be exploited for
+DoS amplification or cache pollution. **All network-adjacent revocation
+lookups** — HTTP fetches of `ListRevoked`, DNS resolution of issuer
+endpoints, writes to a shared revocation cache — MUST be deferred until
+after signature verification.
+
+**Security rationale.** An attacker who can inject an unsigned or
+wrongly-signed TCT can set `tct.issuer` to any AID. If revocation lookup
+runs before signature verification, the verifier will make a network
+request to that AID's revocation endpoint with attacker-chosen
+parameters. This enables (a) network-amplification DoS against arbitrary
+AIDs, (b) revocation-cache pollution under attacker-chosen issuer keys,
+and (c) side-channel disclosure of which AIDs the verifier is willing to
+contact. Anchoring revocation lookup to a *verified* `issuer` and `jti`
+removes all three.
+
 ---
 
 ## 4. Session Revocation

--- a/rfcs/RFC-AITP-0010-session-trust-bundle.md
+++ b/rfcs/RFC-AITP-0010-session-trust-bundle.md
@@ -10,6 +10,21 @@
 
 > **Status: Draft.** Normative text below resolves the four open questions tracked in earlier "Reserved" revisions of this RFC. The bundle wire format and conformance surface are still being implemented; consumers MUST treat the schema as Draft until this RFC is promoted to Release Candidate.
 
+> **Conformance scope.** RFC-AITP-0010 is **not part of AITP v0.1
+> conformance.** Implementations MUST NOT fail v0.1 conformance tests
+> because they do not implement Session Trust Bundles. Conformance
+> runners MUST treat the `bundle-*` fixture set in
+> [`schemas/conformance/`](../schemas/conformance/) as SKIP unless the
+> runner is explicitly opted into testing RFC-AITP-0010 draft conformance
+> (the metadata block on every bundle fixture carries
+> `status: "draft"` and `feature: "experimental-session-bundle"`; see
+> [`schemas/conformance/README.md`](../schemas/conformance/README.md)).
+>
+> The normative requirements in this document (MUST, SHALL, etc.) apply
+> only to implementations that explicitly opt into RFC-AITP-0010 draft
+> conformance. A v0.1-only implementation that ignores Session Trust
+> Bundles entirely is conformant.
+
 ---
 
 ## Abstract

--- a/schemas/conformance/README.md
+++ b/schemas/conformance/README.md
@@ -23,9 +23,18 @@ conformance/
 
 ## Fixture Format
 
+Every fixture MUST carry the following metadata block as its leading
+fields. The block exists so a v0.1 conformance runner can know — without
+parsing scenario content — whether a fixture is required for v0.1, an
+opt-in draft feature, or out of scope entirely.
+
 ```json
 {
   "id": "unique-fixture-id",
+  "rfc": "RFC-AITP-NNNN",
+  "status": "core | draft | extension | reserved",
+  "required_for_v0_1": true,
+  "feature": null,
   "description": "Human-readable description of the scenario",
   "tags": ["happy-path | failure | security | edge-case"],
   "input": { ... },
@@ -36,6 +45,39 @@ conformance/
   }
 }
 ```
+
+### Metadata fields
+
+| Field | Type | Meaning |
+|---|---|---|
+| `id` | string | Fixture id (e.g. `mh-success-001`). |
+| `rfc` | string | Most-specific RFC the fixture exercises (e.g. `RFC-AITP-0006`). |
+| `status` | enum | One of `core`, `draft`, `extension`, `reserved`. See enforcement rules below. |
+| `required_for_v0_1` | bool | Whether a v0.1 implementation MUST pass this fixture. Always `false` for `draft` / `extension` fixtures. |
+| `feature` | string \| null | When `status != "core"`, the named opt-in feature flag a runner uses to enable this fixture (e.g. `experimental-session-bundle`). `null` for core fixtures. |
+
+### Conformance runner enforcement rules
+
+A v0.1 conformance runner MUST apply the following rules to the metadata
+block before executing a fixture:
+
+- `status: "core"` + `required_for_v0_1: true` → **MUST execute.** A
+  `OP_NOT_SUPPORTED` result or runner SKIP MUST be reported as a failure
+  for this fixture.
+- `status: "draft"` → **MUST SKIP** unless the runner has explicitly
+  opted into the named `feature` (and, by extension, draft conformance
+  for the cited RFC). Failing a v0.1 implementation for not implementing
+  a draft fixture is non-conformant runner behavior.
+- `status: "extension"` → **MUST SKIP** in the v0.1 default runner. May
+  be exercised only when the runner is explicitly testing the named
+  extension feature.
+- `status: "reserved"` → MUST be ignored by every runner; reserved status
+  exists only so a fixture id slot can be claimed before the underlying
+  RFC normative text lands.
+
+Any fixture missing the metadata block, or carrying invalid values for
+these fields, MUST cause the runner to fail loudly rather than silently
+skip — the metadata is a load-bearing input to interop testing.
 
 ### Multi-step `sequence` form
 
@@ -142,6 +184,7 @@ The runner interface is implementation-defined.
 |---|---|---|
 | `del-001` | Single-hop happy path — A→B→C with scope ⊆ grant_proof.capabilities | success |
 | `del-003` | Scope exceeds grant_proof capabilities | failure: DELEGATION_SCOPE_EXCEEDED |
+| `del-004` | A delegation token with a non-empty `chain` field MUST be rejected by v0.1 implementations as a structural check, before any per-hop signature work | failure: DELEGATION_MULTIHOP_NOT_SUPPORTED |
 
 ### Multi-hop Delegation (RFC-AITP-0011, post-v0.1)
 

--- a/schemas/conformance/bundle-001-success.json
+++ b/schemas/conformance/bundle-001-success.json
@@ -1,7 +1,15 @@
 {
   "id": "bundle-001",
+  "rfc": "RFC-AITP-0010",
+  "status": "draft",
+  "required_for_v0_1": false,
+  "feature": "experimental-session-bundle",
   "description": "Session Trust Bundle happy path (RFC-AITP-0010 §5). Reuses kat-session-bundle-001 verbatim. Coordinator (kat-keypair-001) has run bilateral Mutual Handshakes with two participants (kat-keypair-002 = B, kat-keypair-003 = C) and minted a peer-issued TCT for each. The bundle packages both TCTs and is signed by the coordinator. The receiving participant (B in this fixture) verifies: bundle version, expiry-window invariant (bundle.expires_at = min(participants[*].tct.expires_at)), participants non-empty, coordinator key resolution, bundle signature, every embedded TCT (issuer = coordinator, audience = participant.aid), and self-membership. All checks pass; B accepts the bundle and the membership it asserts.",
-  "tags": ["success", "session-bundle", "post-v0.1"],
+  "tags": [
+    "success",
+    "session-bundle",
+    "post-v0.1"
+  ],
   "input": {
     "self_aid": "aid:pubkey:A6EHv_POEL4dcN0Y50vAmWfk1jCbpQ1fHdyGZBJVMbg",
     "now": 1711900100,
@@ -23,8 +31,12 @@
               "audience": "aid:pubkey:A6EHv_POEL4dcN0Y50vAmWfk1jCbpQ1fHdyGZBJVMbg",
               "issued_at": 1711900000,
               "expires_at": 1711903600,
-              "grants": ["macp.mode.task.v1"],
-              "binding": {"cnf": "A6EHv_POEL4dcN0Y50vAmWfk1jCbpQ1fHdyGZBJVMbg"},
+              "grants": [
+                "macp.mode.task.v1"
+              ],
+              "binding": {
+                "cnf": "A6EHv_POEL4dcN0Y50vAmWfk1jCbpQ1fHdyGZBJVMbg"
+              },
               "signature": "dRaMvsneooEBb1BrVBvk2ObRANZr_1Q8ajCOzlcBapN86yIwSHXf9uc5PasGHeb22sf7nUC-s_fg7U_hVR34Aw"
             }
           },
@@ -38,8 +50,12 @@
               "audience": "aid:pubkey:dqFZIESm5PURJlvKc6YE2QsFKdHfYCvjChmpJXZg0fU",
               "issued_at": 1711900000,
               "expires_at": 1711905600,
-              "grants": ["macp.mode.task.v1"],
-              "binding": {"cnf": "dqFZIESm5PURJlvKc6YE2QsFKdHfYCvjChmpJXZg0fU"},
+              "grants": [
+                "macp.mode.task.v1"
+              ],
+              "binding": {
+                "cnf": "dqFZIESm5PURJlvKc6YE2QsFKdHfYCvjChmpJXZg0fU"
+              },
               "signature": "gPVK5hq2JCHXP8RAYh1xDbN2qAzR1EfMNpGUJZYbixVohPzK5bWE519ra9WWxXLawAbp9lP-uKgJL9d5uWIBCg"
             }
           }

--- a/schemas/conformance/bundle-002-not-member.json
+++ b/schemas/conformance/bundle-002-not-member.json
@@ -1,7 +1,16 @@
 {
   "id": "bundle-002",
+  "rfc": "RFC-AITP-0010",
+  "status": "draft",
+  "required_for_v0_1": false,
+  "feature": "experimental-session-bundle",
   "description": "Session Trust Bundle membership check (RFC-AITP-0010 §5 step 8). The bundle is byte-identical to bundle-001 — coordinator signature, both embedded TCTs, expiry window, and version checks all pass. The defect is that the receiving participant (kat-keypair-004 / agentD, AID iojj3XQJ...) is NOT in `participants[*].aid`. The verifier MUST reject with BUNDLE_NOT_MEMBER. (A bundle proves coordinator-attested membership; a non-member receiver has no claim on the session.)",
-  "tags": ["security", "session-bundle", "membership", "post-v0.1"],
+  "tags": [
+    "security",
+    "session-bundle",
+    "membership",
+    "post-v0.1"
+  ],
   "input": {
     "self_aid": "aid:pubkey:iojj3XQJ8ZX9UtstPLpdcspnCb8dlBIb83SIAbQPb1w",
     "now": 1711900100,
@@ -23,8 +32,12 @@
               "audience": "aid:pubkey:A6EHv_POEL4dcN0Y50vAmWfk1jCbpQ1fHdyGZBJVMbg",
               "issued_at": 1711900000,
               "expires_at": 1711903600,
-              "grants": ["macp.mode.task.v1"],
-              "binding": {"cnf": "A6EHv_POEL4dcN0Y50vAmWfk1jCbpQ1fHdyGZBJVMbg"},
+              "grants": [
+                "macp.mode.task.v1"
+              ],
+              "binding": {
+                "cnf": "A6EHv_POEL4dcN0Y50vAmWfk1jCbpQ1fHdyGZBJVMbg"
+              },
               "signature": "dRaMvsneooEBb1BrVBvk2ObRANZr_1Q8ajCOzlcBapN86yIwSHXf9uc5PasGHeb22sf7nUC-s_fg7U_hVR34Aw"
             }
           },
@@ -38,8 +51,12 @@
               "audience": "aid:pubkey:dqFZIESm5PURJlvKc6YE2QsFKdHfYCvjChmpJXZg0fU",
               "issued_at": 1711900000,
               "expires_at": 1711905600,
-              "grants": ["macp.mode.task.v1"],
-              "binding": {"cnf": "dqFZIESm5PURJlvKc6YE2QsFKdHfYCvjChmpJXZg0fU"},
+              "grants": [
+                "macp.mode.task.v1"
+              ],
+              "binding": {
+                "cnf": "dqFZIESm5PURJlvKc6YE2QsFKdHfYCvjChmpJXZg0fU"
+              },
               "signature": "gPVK5hq2JCHXP8RAYh1xDbN2qAzR1EfMNpGUJZYbixVohPzK5bWE519ra9WWxXLawAbp9lP-uKgJL9d5uWIBCg"
             }
           }

--- a/schemas/conformance/bundle-003-expired.json
+++ b/schemas/conformance/bundle-003-expired.json
@@ -1,7 +1,16 @@
 {
   "id": "bundle-003",
+  "rfc": "RFC-AITP-0010",
+  "status": "draft",
+  "required_for_v0_1": false,
+  "feature": "experimental-session-bundle",
   "description": "Session Trust Bundle expiry check (RFC-AITP-0010 §5 step 2). Bundle is byte-valid: coordinator signature verifies, embedded TCT signatures verify, expiry-window invariant holds (bundle.expires_at = min(tct.expires_at) = 1711799000), participants non-empty. The defect is that bundle.expires_at = 1711799000 is before `now` = 1711900100. Verifier MUST reject with BUNDLE_EXPIRED before consuming any embedded TCT.",
-  "tags": ["failure", "session-bundle", "expiry", "post-v0.1"],
+  "tags": [
+    "failure",
+    "session-bundle",
+    "expiry",
+    "post-v0.1"
+  ],
   "input": {
     "self_aid": "aid:pubkey:A6EHv_POEL4dcN0Y50vAmWfk1jCbpQ1fHdyGZBJVMbg",
     "now": 1711900100,
@@ -23,8 +32,12 @@
               "audience": "aid:pubkey:A6EHv_POEL4dcN0Y50vAmWfk1jCbpQ1fHdyGZBJVMbg",
               "issued_at": 1711700000,
               "expires_at": 1711800000,
-              "grants": ["macp.mode.task.v1"],
-              "binding": {"cnf": "A6EHv_POEL4dcN0Y50vAmWfk1jCbpQ1fHdyGZBJVMbg"},
+              "grants": [
+                "macp.mode.task.v1"
+              ],
+              "binding": {
+                "cnf": "A6EHv_POEL4dcN0Y50vAmWfk1jCbpQ1fHdyGZBJVMbg"
+              },
               "signature": "3v8isL4MT0Qxn--si6-eP4G09dVlZDKDnVo2MhuCKeVHRPl3YEgnqdtQLYDlB5DeKydP-FHA6ivv0biCR62YBA"
             }
           },
@@ -38,8 +51,12 @@
               "audience": "aid:pubkey:dqFZIESm5PURJlvKc6YE2QsFKdHfYCvjChmpJXZg0fU",
               "issued_at": 1711700000,
               "expires_at": 1711799000,
-              "grants": ["macp.mode.task.v1"],
-              "binding": {"cnf": "dqFZIESm5PURJlvKc6YE2QsFKdHfYCvjChmpJXZg0fU"},
+              "grants": [
+                "macp.mode.task.v1"
+              ],
+              "binding": {
+                "cnf": "dqFZIESm5PURJlvKc6YE2QsFKdHfYCvjChmpJXZg0fU"
+              },
               "signature": "n_ptxhEzDZ00XU_2WozZqwkvJ3iXzaafj9tHMFfOZEA8X4NeH3-Zcru6banieKT3KZdzxI30GQXZUVfJNztfAA"
             }
           }

--- a/schemas/conformance/del-001-success.json
+++ b/schemas/conformance/del-001-success.json
@@ -1,5 +1,9 @@
 {
   "id": "del-001",
+  "rfc": "RFC-AITP-0006",
+  "status": "core",
+  "required_for_v0_1": true,
+  "feature": null,
   "description": "Single-hop delegation happy path. A peer-issued [read_data, write_data] to B (kat-keypair-001 → kat-keypair-002). B delegates [read_data] (a strict subset) to C (kat-keypair-003) with audience=A. A verifies the grant_proof signature against its own key, the scope subset, the audience, the expiry, and B's outer signature against B's Manifest key. All checks pass; A would mint a fresh peer-issued TCT for C carrying the delegated subset. (RFC-AITP-0006 §4.) The success counterpart to del-003-scope-exceeded.",
   "tags": [
     "success",

--- a/schemas/conformance/del-003-scope-exceeded.json
+++ b/schemas/conformance/del-003-scope-exceeded.json
@@ -1,5 +1,9 @@
 {
   "id": "del-003",
+  "rfc": "RFC-AITP-0006",
+  "status": "core",
+  "required_for_v0_1": true,
+  "feature": null,
   "description": "Delegation scope exceeds grant_proof capabilities. MUST be rejected.",
   "tags": [
     "security",

--- a/schemas/conformance/del-004-multihop-rejected-v01.json
+++ b/schemas/conformance/del-004-multihop-rejected-v01.json
@@ -1,0 +1,59 @@
+{
+  "id": "del-004",
+  "rfc": "RFC-AITP-0006",
+  "status": "core",
+  "required_for_v0_1": true,
+  "feature": null,
+  "description": "A delegation token whose `chain` field is non-empty MUST be rejected by a v0.1 implementation with DELEGATION_MULTIHOP_NOT_SUPPORTED, regardless of any other validity property of the token. RFC-AITP-0006 §9 forbids multi-hop verification in v0.1; the chain field is the trigger. The runner MUST reject before performing any per-hop signature work — the multi-hop rejection is a structural/early check, not the result of failed verification. Multi-hop acceptance semantics are reserved for RFC-AITP-0011 (Draft, post-v0.1) and exercised by the `del-mh-*` opt-in fixture set.",
+  "tags": [
+    "security",
+    "delegation",
+    "multi-hop",
+    "v0.1-rejection"
+  ],
+  "input": {
+    "delegation": {
+      "delegator": "aid:pubkey:O2onvM62pC1io6jQKm8Nc2UyFXcd4kOmOsBIoYtZ2ik",
+      "delegatee": "aid:pubkey:dqFZIESm5PURJlvKc6YE2QsFKdHfYCvjChmpJXZg0fU",
+      "issued_by": "aid:pubkey:A6EHv_POEL4dcN0Y50vAmWfk1jCbpQ1fHdyGZBJVMbg",
+      "audience": "aid:pubkey:O2onvM62pC1io6jQKm8Nc2UyFXcd4kOmOsBIoYtZ2ik",
+      "scope": [
+        "read_data"
+      ],
+      "expires_at": 9999999999,
+      "cnf": "dqFZIESm5PURJlvKc6YE2QsFKdHfYCvjChmpJXZg0fU",
+      "grant_proof": {
+        "issuer": "aid:pubkey:O2onvM62pC1io6jQKm8Nc2UyFXcd4kOmOsBIoYtZ2ik",
+        "subject": "aid:pubkey:A6EHv_POEL4dcN0Y50vAmWfk1jCbpQ1fHdyGZBJVMbg",
+        "capabilities": [
+          "read_data"
+        ],
+        "issued_at": 1711900000,
+        "expires_at": 9999999999,
+        "source_tct_jti": "550e8400-e29b-41d4-a716-446655440099",
+        "signature": "__VALID_GRANT_PROOF_SIG__"
+      },
+      "chain": [
+        {
+          "issuer": "aid:pubkey:O2onvM62pC1io6jQKm8Nc2UyFXcd4kOmOsBIoYtZ2ik",
+          "subject": "aid:pubkey:A6EHv_POEL4dcN0Y50vAmWfk1jCbpQ1fHdyGZBJVMbg",
+          "capabilities": [
+            "read_data"
+          ],
+          "issued_at": 1711900000,
+          "expires_at": 9999999999,
+          "source_tct_jti": "550e8400-e29b-41d4-a716-446655440098",
+          "signature": "__ANY_CHAIN_STEP_SIG__"
+        }
+      ],
+      "chain_hash": "__ANY_CHAIN_HASH__",
+      "signature": "__ANY_DELEGATION_SIG__"
+    },
+    "operation": "verify_delegation_token"
+  },
+  "expected": {
+    "outcome": "failure",
+    "error_code": "DELEGATION_MULTIHOP_NOT_SUPPORTED",
+    "rationale": "The `chain` field is non-empty. A v0.1 implementation MUST reject before any signature, scope, or chain-hash verification is performed. The placeholder values for chain-step / chain-hash / outer signatures are deliberate: this fixture asserts the early structural check, not failed cryptographic verification."
+  }
+}

--- a/schemas/conformance/del-mh-001-success.json
+++ b/schemas/conformance/del-mh-001-success.json
@@ -1,20 +1,33 @@
 {
   "id": "del-mh-001",
+  "rfc": "RFC-AITP-0011",
+  "status": "draft",
+  "required_for_v0_1": false,
+  "feature": "experimental-multihop-delegation",
   "description": "Multi-hop delegation happy path (3 hops, A→B→C→D). Reuses kat-multihop-chain-001 verbatim. chain[0] is A's peer-issued TCT to B (in GrantProof shape; A's signature reused from the source TCT). chain[1] is B's intermediate-signed step delegating [read_data] to C. grant_proof is C's intermediate-signed step authorizing C to issue to D. delegation.signature is C's outer signature; chain_hash is base64url(sha256(JCS([chain[0].source_tct_jti, chain[1].source_tct_jti]))). A verifies every hop's signature, the transitive scope subsetting (read_data ⊆ read_data ⊆ [read_data, write_data]), the chain_hash, and the outer signature. All checks pass; A peer-issues a fresh TCT for D. (RFC-AITP-0011 §3, §4, §5.) NOTE: post-v0.1 — v0.1 implementations MUST reject any token with a non-empty `chain` field with DELEGATION_MULTIHOP_NOT_SUPPORTED.",
-  "tags": ["success", "delegation", "multi-hop", "post-v0.1"],
+  "tags": [
+    "success",
+    "delegation",
+    "multi-hop",
+    "post-v0.1"
+  ],
   "input": {
     "delegation": {
       "delegator": "aid:pubkey:O2onvM62pC1io6jQKm8Nc2UyFXcd4kOmOsBIoYtZ2ik",
       "delegatee": "aid:pubkey:iojj3XQJ8ZX9UtstPLpdcspnCb8dlBIb83SIAbQPb1w",
       "issued_by": "aid:pubkey:dqFZIESm5PURJlvKc6YE2QsFKdHfYCvjChmpJXZg0fU",
       "audience": "aid:pubkey:O2onvM62pC1io6jQKm8Nc2UyFXcd4kOmOsBIoYtZ2ik",
-      "scope": ["read_data"],
+      "scope": [
+        "read_data"
+      ],
       "expires_at": 1711903600,
       "cnf": "iojj3XQJ8ZX9UtstPLpdcspnCb8dlBIb83SIAbQPb1w",
       "grant_proof": {
         "issuer": "aid:pubkey:dqFZIESm5PURJlvKc6YE2QsFKdHfYCvjChmpJXZg0fU",
         "subject": "aid:pubkey:iojj3XQJ8ZX9UtstPLpdcspnCb8dlBIb83SIAbQPb1w",
-        "capabilities": ["read_data"],
+        "capabilities": [
+          "read_data"
+        ],
         "issued_at": 1711900200,
         "expires_at": 1711903600,
         "source_tct_jti": "550e8400-e29b-41d4-a716-446655443003",
@@ -24,7 +37,10 @@
         {
           "issuer": "aid:pubkey:O2onvM62pC1io6jQKm8Nc2UyFXcd4kOmOsBIoYtZ2ik",
           "subject": "aid:pubkey:A6EHv_POEL4dcN0Y50vAmWfk1jCbpQ1fHdyGZBJVMbg",
-          "capabilities": ["read_data", "write_data"],
+          "capabilities": [
+            "read_data",
+            "write_data"
+          ],
           "issued_at": 1711900000,
           "expires_at": 1711905000,
           "source_tct_jti": "550e8400-e29b-41d4-a716-446655443001",
@@ -33,7 +49,9 @@
         {
           "issuer": "aid:pubkey:A6EHv_POEL4dcN0Y50vAmWfk1jCbpQ1fHdyGZBJVMbg",
           "subject": "aid:pubkey:dqFZIESm5PURJlvKc6YE2QsFKdHfYCvjChmpJXZg0fU",
-          "capabilities": ["read_data"],
+          "capabilities": [
+            "read_data"
+          ],
           "issued_at": 1711900100,
           "expires_at": 1711904000,
           "source_tct_jti": "550e8400-e29b-41d4-a716-446655443002",
@@ -47,7 +65,9 @@
   },
   "expected": {
     "outcome": "success",
-    "grants": ["read_data"],
+    "grants": [
+      "read_data"
+    ],
     "rationale": "Per-hop signatures verify under each issuer's key; transitive scope check passes (read_data ⊆ read_data ⊆ [read_data, write_data]); chain_hash recomputes from JTI list; outer signature verifies under C's key."
   }
 }

--- a/schemas/conformance/del-mh-002-scope-inflation.json
+++ b/schemas/conformance/del-mh-002-scope-inflation.json
@@ -1,5 +1,9 @@
 {
   "id": "del-mh-002",
+  "rfc": "RFC-AITP-0011",
+  "status": "draft",
+  "required_for_v0_1": false,
+  "feature": "experimental-multihop-delegation",
   "description": "Multi-hop scope inflation. chain[1] (B→C) declares capabilities=[\"read_data\",\"admin\"], but chain[0] (A→B) granted only [\"read_data\",\"write_data\"]. The transitive scope check (RFC-AITP-0011 §4) requires chain[1].capabilities ⊆ chain[0].capabilities; \"admin\" violates that. All per-hop signatures are valid (so a *single*-hop adjacent-only check would not catch this — only the full transitive chain does). Verifier MUST reject with DELEGATION_SCOPE_EXCEEDED.",
   "tags": [
     "security",

--- a/schemas/conformance/del-mh-003-chain-hash-mismatch.json
+++ b/schemas/conformance/del-mh-003-chain-hash-mismatch.json
@@ -1,20 +1,34 @@
 {
   "id": "del-mh-003",
+  "rfc": "RFC-AITP-0011",
+  "status": "draft",
+  "required_for_v0_1": false,
+  "feature": "experimental-multihop-delegation",
   "description": "Multi-hop chain_hash truncation defense. The chain and per-hop signatures are valid (identical to del-mh-001), but `chain_hash` has been tampered (does not match base64url(sha256(JCS([chain[0].source_tct_jti, chain[1].source_tct_jti])))). The verifier MUST recompute chain_hash from the chain contents and reject on mismatch with DELEGATION_CHAIN_HASH_MISMATCH (RFC-AITP-0011 §5). This is the canonical truncation-detection vector — equivalent to dropping a hop, since the outer signature covers chain_hash. Note: since chain_hash is bound into the outer signature, mutating it also invalidates `delegation.signature`; an implementation MAY also report DELEGATION_INVALID_SIGNATURE depending on which check it runs first. The chain_hash check is the more diagnostic one (the canonical pinned value lives at kat-multihop-truncation-001).",
-  "tags": ["security", "delegation", "multi-hop", "chain-hash", "post-v0.1"],
+  "tags": [
+    "security",
+    "delegation",
+    "multi-hop",
+    "chain-hash",
+    "post-v0.1"
+  ],
   "input": {
     "delegation": {
       "delegator": "aid:pubkey:O2onvM62pC1io6jQKm8Nc2UyFXcd4kOmOsBIoYtZ2ik",
       "delegatee": "aid:pubkey:iojj3XQJ8ZX9UtstPLpdcspnCb8dlBIb83SIAbQPb1w",
       "issued_by": "aid:pubkey:dqFZIESm5PURJlvKc6YE2QsFKdHfYCvjChmpJXZg0fU",
       "audience": "aid:pubkey:O2onvM62pC1io6jQKm8Nc2UyFXcd4kOmOsBIoYtZ2ik",
-      "scope": ["read_data"],
+      "scope": [
+        "read_data"
+      ],
       "expires_at": 1711903600,
       "cnf": "iojj3XQJ8ZX9UtstPLpdcspnCb8dlBIb83SIAbQPb1w",
       "grant_proof": {
         "issuer": "aid:pubkey:dqFZIESm5PURJlvKc6YE2QsFKdHfYCvjChmpJXZg0fU",
         "subject": "aid:pubkey:iojj3XQJ8ZX9UtstPLpdcspnCb8dlBIb83SIAbQPb1w",
-        "capabilities": ["read_data"],
+        "capabilities": [
+          "read_data"
+        ],
         "issued_at": 1711900200,
         "expires_at": 1711903600,
         "source_tct_jti": "550e8400-e29b-41d4-a716-446655443003",
@@ -24,7 +38,10 @@
         {
           "issuer": "aid:pubkey:O2onvM62pC1io6jQKm8Nc2UyFXcd4kOmOsBIoYtZ2ik",
           "subject": "aid:pubkey:A6EHv_POEL4dcN0Y50vAmWfk1jCbpQ1fHdyGZBJVMbg",
-          "capabilities": ["read_data", "write_data"],
+          "capabilities": [
+            "read_data",
+            "write_data"
+          ],
           "issued_at": 1711900000,
           "expires_at": 1711905000,
           "source_tct_jti": "550e8400-e29b-41d4-a716-446655443001",
@@ -33,7 +50,9 @@
         {
           "issuer": "aid:pubkey:A6EHv_POEL4dcN0Y50vAmWfk1jCbpQ1fHdyGZBJVMbg",
           "subject": "aid:pubkey:dqFZIESm5PURJlvKc6YE2QsFKdHfYCvjChmpJXZg0fU",
-          "capabilities": ["read_data"],
+          "capabilities": [
+            "read_data"
+          ],
           "issued_at": 1711900100,
           "expires_at": 1711904000,
           "source_tct_jti": "550e8400-e29b-41d4-a716-446655443002",

--- a/schemas/conformance/del-mh-004-revoked-hop.json
+++ b/schemas/conformance/del-mh-004-revoked-hop.json
@@ -1,20 +1,34 @@
 {
   "id": "del-mh-004",
+  "rfc": "RFC-AITP-0011",
+  "status": "draft",
+  "required_for_v0_1": false,
+  "feature": "experimental-multihop-delegation",
   "description": "Multi-hop per-hop revocation (RFC-AITP-0011 §6). The chain (identical to del-mh-001) is structurally valid: per-hop signatures verify, transitive scope subsetting passes, chain_hash recomputes, outer signature verifies. However, B's signed revocation snapshot (B = chain[1].issuer) lists chain[1].source_tct_jti = 550e8400-e29b-41d4-a716-446655443002 in `entries`. Per RFC-AITP-0011 §6, the verifier MUST check every chain[i].source_tct_jti against chain[i].issuer's deny list, and a revocation hit at ANY hop invalidates the entire delegation. Expected: DELEGATION_SOURCE_TCT_REVOKED.",
-  "tags": ["security", "delegation", "multi-hop", "revocation", "post-v0.1"],
+  "tags": [
+    "security",
+    "delegation",
+    "multi-hop",
+    "revocation",
+    "post-v0.1"
+  ],
   "input": {
     "delegation": {
       "delegator": "aid:pubkey:O2onvM62pC1io6jQKm8Nc2UyFXcd4kOmOsBIoYtZ2ik",
       "delegatee": "aid:pubkey:iojj3XQJ8ZX9UtstPLpdcspnCb8dlBIb83SIAbQPb1w",
       "issued_by": "aid:pubkey:dqFZIESm5PURJlvKc6YE2QsFKdHfYCvjChmpJXZg0fU",
       "audience": "aid:pubkey:O2onvM62pC1io6jQKm8Nc2UyFXcd4kOmOsBIoYtZ2ik",
-      "scope": ["read_data"],
+      "scope": [
+        "read_data"
+      ],
       "expires_at": 1711903600,
       "cnf": "iojj3XQJ8ZX9UtstPLpdcspnCb8dlBIb83SIAbQPb1w",
       "grant_proof": {
         "issuer": "aid:pubkey:dqFZIESm5PURJlvKc6YE2QsFKdHfYCvjChmpJXZg0fU",
         "subject": "aid:pubkey:iojj3XQJ8ZX9UtstPLpdcspnCb8dlBIb83SIAbQPb1w",
-        "capabilities": ["read_data"],
+        "capabilities": [
+          "read_data"
+        ],
         "issued_at": 1711900200,
         "expires_at": 1711903600,
         "source_tct_jti": "550e8400-e29b-41d4-a716-446655443003",
@@ -24,7 +38,10 @@
         {
           "issuer": "aid:pubkey:O2onvM62pC1io6jQKm8Nc2UyFXcd4kOmOsBIoYtZ2ik",
           "subject": "aid:pubkey:A6EHv_POEL4dcN0Y50vAmWfk1jCbpQ1fHdyGZBJVMbg",
-          "capabilities": ["read_data", "write_data"],
+          "capabilities": [
+            "read_data",
+            "write_data"
+          ],
           "issued_at": 1711900000,
           "expires_at": 1711905000,
           "source_tct_jti": "550e8400-e29b-41d4-a716-446655443001",
@@ -33,7 +50,9 @@
         {
           "issuer": "aid:pubkey:A6EHv_POEL4dcN0Y50vAmWfk1jCbpQ1fHdyGZBJVMbg",
           "subject": "aid:pubkey:dqFZIESm5PURJlvKc6YE2QsFKdHfYCvjChmpJXZg0fU",
-          "capabilities": ["read_data"],
+          "capabilities": [
+            "read_data"
+          ],
           "issued_at": 1711900100,
           "expires_at": 1711904000,
           "source_tct_jti": "550e8400-e29b-41d4-a716-446655443002",

--- a/schemas/conformance/env-001-timestamp-expired.json
+++ b/schemas/conformance/env-001-timestamp-expired.json
@@ -1,5 +1,9 @@
 {
   "id": "env-001",
+  "rfc": "RFC-AITP-0001",
+  "status": "core",
+  "required_for_v0_1": true,
+  "feature": null,
   "description": "Envelope timestamp is older than the receiver's tolerance window. Receivers MUST reject with TIMESTAMP_EXPIRED (RFC-AITP-0001 §5.5). Retryable.",
   "tags": [
     "security",

--- a/schemas/conformance/env-002-policy-violation.json
+++ b/schemas/conformance/env-002-policy-violation.json
@@ -1,5 +1,9 @@
 {
   "id": "env-002",
+  "rfc": "RFC-AITP-0004",
+  "status": "core",
+  "required_for_v0_1": true,
+  "feature": null,
   "description": "Caller invokes a capability not present in the active TCT's grants. Receivers MUST reject with POLICY_VIOLATION (RFC-AITP-0004 §4). The check is local — no remote lookup is required.",
   "tags": [
     "failure",

--- a/schemas/conformance/env-003-key-resolution-failed.json
+++ b/schemas/conformance/env-003-key-resolution-failed.json
@@ -1,5 +1,9 @@
 {
   "id": "env-003",
+  "rfc": "RFC-AITP-0007",
+  "status": "core",
+  "required_for_v0_1": true,
+  "feature": null,
   "description": "Verifier cannot resolve the issuing peer's signing key (Manifest unreachable, OIDC discovery offline, or no entry in pinned/well-known fallbacks). Receivers MUST reject with KEY_RESOLUTION_FAILED (RFC-AITP-0007). Retryable.",
   "tags": [
     "failure",

--- a/schemas/conformance/env-004-replay-message-id-rejected.json
+++ b/schemas/conformance/env-004-replay-message-id-rejected.json
@@ -1,5 +1,9 @@
 {
   "id": "env-004",
+  "rfc": "RFC-AITP-0001",
+  "status": "core",
+  "required_for_v0_1": true,
+  "feature": null,
   "description": "Two envelopes carrying the same `message_id` within the verifier's replay window MUST result in the second being rejected with REPLAY_DETECTED. The first envelope MUST be accepted (or rejected for a non-replay reason). The window MUST be at least `iat_tolerance_secs`; alpha.5 ships a 300 s default (RFC-AITP-0001 §5.5; alpha.5 P8). The HTTP transport applies this check at the boundary, before payload parsing.",
   "tags": [
     "security",

--- a/schemas/conformance/id-001-oidc-missing-aud.json
+++ b/schemas/conformance/id-001-oidc-missing-aud.json
@@ -1,5 +1,9 @@
 {
   "id": "id-001",
+  "rfc": "RFC-AITP-0002",
+  "status": "core",
+  "required_for_v0_1": true,
+  "feature": null,
   "description": "Peer's OIDC identity JWT is otherwise valid but is missing the `aud` claim. Without `aud`, the verifier cannot confirm the JWT was minted for this peer; the receiving peer MUST reject with IDENTITY_FAILED (RFC-AITP-0002 §2.2).",
   "tags": [
     "security",

--- a/schemas/conformance/id-002-oidc-wrong-aud.json
+++ b/schemas/conformance/id-002-oidc-wrong-aud.json
@@ -1,5 +1,9 @@
 {
   "id": "id-002",
+  "rfc": "RFC-AITP-0002",
+  "status": "core",
+  "required_for_v0_1": true,
+  "feature": null,
   "description": "Peer's OIDC identity JWT carries an `aud` claim that targets a different peer's AID, not the receiving peer's. The receiving peer MUST reject with IDENTITY_FAILED — accepting a JWT minted for someone else would allow the holder to impersonate the subject across audiences (RFC-AITP-0002 §2.2).",
   "tags": [
     "security",

--- a/schemas/conformance/id-003-oidc-missing-cnf-jkt.json
+++ b/schemas/conformance/id-003-oidc-missing-cnf-jkt.json
@@ -1,5 +1,9 @@
 {
   "id": "id-003",
+  "rfc": "RFC-AITP-0002",
+  "status": "core",
+  "required_for_v0_1": true,
+  "feature": null,
   "description": "Peer's OIDC identity JWT is otherwise valid but is missing the `cnf.jkt` claim. Without `cnf.jkt` the verifier cannot bind the JWT to the AID's public key — anyone could replay the JWT against a different AID. The receiving peer MUST reject with IDENTITY_FAILED (RFC-AITP-0002 §2.3).",
   "tags": [
     "security",

--- a/schemas/conformance/id-004-pinned-key-cross-peer-replay.json
+++ b/schemas/conformance/id-004-pinned-key-cross-peer-replay.json
@@ -1,5 +1,9 @@
 {
   "id": "id-004",
+  "rfc": "RFC-AITP-0002",
+  "status": "core",
+  "required_for_v0_1": true,
+  "feature": null,
   "description": "Attacker captures a valid pinned-key identity proof from a previous handshake and replays it inside a fresh MUTUAL_HELLO addressed to a different receiver. The replayed envelope is well-formed and the signature still verifies under the original signer's public key, but the pinned-key proof input (RFC-AITP-0002 §3.1) binds the original sender, receiver, message_id, timestamp, and pop_nonce. The receiving peer reconstructs the proof input using its own AID as receiver and the new envelope's message_id, timestamp, and pop_nonce, and the signature MUST fail to verify. Receiver MUST reject with IDENTITY_FAILED.",
   "tags": [
     "security",

--- a/schemas/conformance/id-005-pinned-legacy-proof-rejected.json
+++ b/schemas/conformance/id-005-pinned-legacy-proof-rejected.json
@@ -1,5 +1,9 @@
 {
   "id": "id-005",
+  "rfc": "RFC-AITP-0002",
+  "status": "core",
+  "required_for_v0_1": true,
+  "feature": null,
   "description": "A pinned-key proof signed using the pre-v0.1 two-field input (`message_id|timestamp`, no domain prefix, no receiver, no pop_nonce) MUST be rejected with IDENTITY_FAILED. The v0.1 normative proof input is the five-field domain-prefixed form (RFC-AITP-0002 §3.1). This fixture pins the cross-version regression: an alpha.4 implementation that rolled forward unchanged would silently accept the legacy proof. The minting tool produces the legacy signature in `__LEGACY_PINNED_PROOF__` so the fixture's signature alphabet is real and the verifier must replay the v0.1 reconstruction to discover the mismatch. (alpha.5 P1.)",
   "tags": [
     "security",

--- a/schemas/conformance/id-006-pinned-wrong-pop-nonce-rejected.json
+++ b/schemas/conformance/id-006-pinned-wrong-pop-nonce-rejected.json
@@ -1,5 +1,9 @@
 {
   "id": "id-006",
+  "rfc": "RFC-AITP-0002",
+  "status": "core",
+  "required_for_v0_1": true,
+  "feature": null,
   "description": "A pinned-key proof signed with a different `pop_nonce` than the envelope advertises MUST be rejected with IDENTITY_FAILED. The pop_nonce is one of the five proof-input fields (RFC-AITP-0002 §3.1); a verifier reconstructing the input with the envelope's payload.pop_nonce will not produce the same digest the signer used. (alpha.5 P1.)",
   "tags": [
     "security",

--- a/schemas/conformance/id-007-pinned-untrusted-key-rejected.json
+++ b/schemas/conformance/id-007-pinned-untrusted-key-rejected.json
@@ -1,5 +1,9 @@
 {
   "id": "id-007",
+  "rfc": "RFC-AITP-0002",
+  "status": "core",
+  "required_for_v0_1": true,
+  "feature": null,
   "description": "A pinned-key proof whose 32-byte public key is not present in the verifier's local pinned-key trust store MUST be rejected with IDENTITY_FAILED — even when the proof signature is cryptographically valid (RFC-AITP-0002 §3.2 step 1; alpha.5 P3). Without this gate the proof only proves key possession; it does not prove the verifier should *honor* keys it has never seen. The fixture supplies a concrete `trust_store` to make the policy decision deterministic.",
   "tags": [
     "security",

--- a/schemas/conformance/man-001-expired.json
+++ b/schemas/conformance/man-001-expired.json
@@ -1,5 +1,9 @@
 {
   "id": "man-001",
+  "rfc": "RFC-AITP-0003",
+  "status": "core",
+  "required_for_v0_1": true,
+  "feature": null,
   "description": "Manifest `expires_at` is in the past at fetch time. Receivers MUST reject with MANIFEST_EXPIRED (RFC-AITP-0003 §5) and MUST NOT initiate a Mutual Handshake against the stale Manifest.",
   "tags": [
     "failure",

--- a/schemas/conformance/man-002-version-unknown.json
+++ b/schemas/conformance/man-002-version-unknown.json
@@ -1,5 +1,9 @@
 {
   "id": "man-002",
+  "rfc": "RFC-AITP-0003",
+  "status": "core",
+  "required_for_v0_1": true,
+  "feature": null,
   "description": "Manifest declares a `version` the receiver does not implement. Receivers MUST reject with MANIFEST_VERSION_UNKNOWN (RFC-AITP-0003) and MUST NOT attempt best-effort parsing of an unknown major version.",
   "tags": [
     "failure",

--- a/schemas/conformance/man-003-cache-expired-rejected.json
+++ b/schemas/conformance/man-003-cache-expired-rejected.json
@@ -1,5 +1,9 @@
 {
   "id": "man-003",
+  "rfc": "RFC-AITP-0003",
+  "status": "core",
+  "required_for_v0_1": true,
+  "feature": null,
   "description": "Cached Manifest whose `expires_at` predates the verifier's current time MUST NOT be returned by `cached_manifest()` and MUST NOT be used for handshake bootstrap. Implementations that store Manifests in a local cache MUST honor `expires_at` on every read; serving a stale cached entry is treated as MANIFEST_EXPIRED. (RFC-AITP-0003 §4.2; alpha.5 P11.)",
   "tags": [
     "failure",

--- a/schemas/conformance/mh-001-replay-rejected.json
+++ b/schemas/conformance/mh-001-replay-rejected.json
@@ -1,5 +1,9 @@
 {
   "id": "mh-001",
+  "rfc": "RFC-AITP-0004",
+  "status": "core",
+  "required_for_v0_1": true,
+  "feature": null,
   "description": "Replayed MUTUAL_HELLO (duplicate message_id) MUST be rejected on the second send.",
   "tags": [
     "security",

--- a/schemas/conformance/mh-002-manifest-signature-invalid.json
+++ b/schemas/conformance/mh-002-manifest-signature-invalid.json
@@ -1,5 +1,9 @@
 {
   "id": "mh-002",
+  "rfc": "RFC-AITP-0004",
+  "status": "core",
+  "required_for_v0_1": true,
+  "feature": null,
   "description": "Peer's inline Manifest carries an invalid signature. The receiving peer MUST reject the handshake before any further processing.",
   "tags": [
     "security",

--- a/schemas/conformance/mh-003-manifest-pop-failed.json
+++ b/schemas/conformance/mh-003-manifest-pop-failed.json
@@ -1,6 +1,10 @@
 {
   "id": "mh-003",
-  "description": "Peer's Manifest signature validates but its proof_of_possession.signature does not validate against manifest.aid. The receiving peer MUST reject the handshake \u2014 the Manifest could be a replay across agents.",
+  "rfc": "RFC-AITP-0004",
+  "status": "core",
+  "required_for_v0_1": true,
+  "feature": null,
+  "description": "Peer's Manifest signature validates but its proof_of_possession.signature does not validate against manifest.aid. The receiving peer MUST reject the handshake — the Manifest could be a replay across agents.",
   "tags": [
     "security",
     "mutual-handshake",

--- a/schemas/conformance/mh-004-incompatible-trust-anchors.json
+++ b/schemas/conformance/mh-004-incompatible-trust-anchors.json
@@ -1,5 +1,9 @@
 {
   "id": "mh-004",
+  "rfc": "RFC-AITP-0004",
+  "status": "core",
+  "required_for_v0_1": true,
+  "feature": null,
   "description": "Peer's identity issuer is not present in the receiving peer's trust_anchors. The handshake MUST fail with INCOMPATIBLE_TRUST_ANCHORS — there is no shared verifier in v0.1.",
   "tags": [
     "mutual-handshake",

--- a/schemas/conformance/mh-005-nonce-mismatch.json
+++ b/schemas/conformance/mh-005-nonce-mismatch.json
@@ -1,5 +1,9 @@
 {
   "id": "mh-005",
+  "rfc": "RFC-AITP-0004",
+  "status": "core",
+  "required_for_v0_1": true,
+  "feature": null,
   "description": "MUTUAL_HELLO_ACK carries a pop_nonce_echo that does not match the pop_nonce the initiator sent in MUTUAL_HELLO. The initiator MUST reject the handshake with NONCE_MISMATCH — without echo binding, an attacker could inject a fabricated ACK referencing different nonces.",
   "tags": [
     "security",

--- a/schemas/conformance/mh-006-audience-mismatch.json
+++ b/schemas/conformance/mh-006-audience-mismatch.json
@@ -1,5 +1,9 @@
 {
   "id": "mh-006",
+  "rfc": "RFC-AITP-0004",
+  "status": "core",
+  "required_for_v0_1": true,
+  "feature": null,
   "description": "Peer-issued TCT delivered in MUTUAL_COMMIT_ACK has an audience that is not the receiving peer's own AID. The receiving peer MUST reject with AUDIENCE_MISMATCH — the TCT could be a redirected token bound to a different agent.",
   "tags": [
     "security",

--- a/schemas/conformance/mh-007-grant-overflow.json
+++ b/schemas/conformance/mh-007-grant-overflow.json
@@ -1,5 +1,9 @@
 {
   "id": "mh-007",
+  "rfc": "RFC-AITP-0004",
+  "status": "core",
+  "required_for_v0_1": true,
+  "feature": null,
   "description": "Peer-issued TCT carries grants that exceed the issuing peer's offered_capabilities (declared in its Manifest). The receiving peer MUST reject with GRANT_OVERFLOW — a peer cannot grant capabilities it did not publicly offer.",
   "tags": [
     "security",

--- a/schemas/conformance/mh-008-pop-verification-failed.json
+++ b/schemas/conformance/mh-008-pop-verification-failed.json
@@ -1,5 +1,9 @@
 {
   "id": "mh-008",
+  "rfc": "RFC-AITP-0004",
+  "status": "core",
+  "required_for_v0_1": true,
+  "feature": null,
   "description": "MUTUAL_COMMIT carries a pop_signature that does not validate against the sender's AID public key when verified over sha256(receiver_pop_nonce). The receiver MUST reject with POP_VERIFICATION_FAILED — without a valid PoP the sender has not proven possession of the live private key.",
   "tags": [
     "security",

--- a/schemas/conformance/mh-009-identity-type-mismatch-rejected.json
+++ b/schemas/conformance/mh-009-identity-type-mismatch-rejected.json
@@ -1,5 +1,9 @@
 {
   "id": "mh-009",
+  "rfc": "RFC-AITP-0004",
+  "status": "core",
+  "required_for_v0_1": true,
+  "feature": null,
   "description": "Manifest declares `identity_hint.type = oidc` but the handshake payload presents a `pinned_key` identity proof (or vice versa). Receiver MUST reject with IDENTITY_FAILED. Without this gate, an attacker could downgrade an OIDC-only peer to pinned-key verification and bypass the OIDC trust-anchor checks (type confusion). (RFC-AITP-0002 §3 / RFC-AITP-0004 §5.1; alpha.5 P4.)",
   "tags": [
     "security",

--- a/schemas/conformance/mh-success-001.json
+++ b/schemas/conformance/mh-success-001.json
@@ -1,5 +1,9 @@
 {
   "id": "mh-success-001",
+  "rfc": "RFC-AITP-0004",
+  "status": "core",
+  "required_for_v0_1": true,
+  "feature": null,
   "description": "Happy-path Mutual Handshake. Both peers present valid OIDC identity proofs bound to the per-handshake nonces, exchange Manifests with valid signatures and PoP, and emit two valid peer-issued TCTs. Each peer's `requested_grants` is contained in the other peer's `offered_capabilities`. Both peers MUST accept and store the inbound TCT.",
   "tags": [
     "happy-path",

--- a/schemas/conformance/rev-001-stale-snapshot-fail-closed.json
+++ b/schemas/conformance/rev-001-stale-snapshot-fail-closed.json
@@ -1,5 +1,9 @@
 {
   "id": "rev-001",
+  "rfc": "RFC-AITP-0008",
+  "status": "core",
+  "required_for_v0_1": true,
+  "feature": null,
   "description": "A signed revocation snapshot whose `published_at` exceeds the verifier's `max_staleness_secs` policy MUST be treated as no-snapshot. Implementations configured `FailClosed` MUST then reject the underlying TCT with TCT_REVOKED (or KEY_RESOLUTION_FAILED, depending on the call site). The snapshot here is otherwise well-formed and signed by the issuer; only its age trips the policy. (RFC-AITP-0008 §1.5; alpha.5 P12.)",
   "tags": [
     "failure",

--- a/schemas/conformance/rev-002-soft-fail-safe-subset.json
+++ b/schemas/conformance/rev-002-soft-fail-safe-subset.json
@@ -1,5 +1,9 @@
 {
   "id": "rev-002",
+  "rfc": "RFC-AITP-0008",
+  "status": "core",
+  "required_for_v0_1": true,
+  "feature": null,
   "description": "Same shape as `rev-001`, but the verifier's policy is `SoftFail`: a stale or unreachable snapshot MUST NOT cause hard rejection. Implementations MAY emit telemetry; the wire-level outcome is `success` (or, equivalently, `revoked = false`). This fixture protects callers that prefer availability over revocation freshness in low-value flows. (RFC-AITP-0008 §1.5; alpha.5 P12.)",
   "tags": [
     "success",

--- a/schemas/conformance/rev-003-success.json
+++ b/schemas/conformance/rev-003-success.json
@@ -1,5 +1,9 @@
 {
   "id": "rev-003",
+  "rfc": "RFC-AITP-0008",
+  "status": "core",
+  "required_for_v0_1": true,
+  "feature": null,
   "description": "Revocation snapshot happy path. A signed snapshot from the issuing peer (kat-keypair-001) is fresh (published_at within `max_staleness_secs`), its signature validates under the issuing peer's Manifest key, and a queried JTI is NOT in `entries`. Verifier returns 'not revoked' and the surrounding TCT verification continues. (RFC-AITP-0008 §1.5.) Counterpart to rev-001 (stale snapshot, fail-closed) and rev-002 (stale snapshot, soft-fail).",
   "tags": [
     "success",

--- a/schemas/conformance/tct-002-expired.json
+++ b/schemas/conformance/tct-002-expired.json
@@ -1,5 +1,9 @@
 {
   "id": "tct-002",
+  "rfc": "RFC-AITP-0005",
+  "status": "core",
+  "required_for_v0_1": true,
+  "feature": null,
   "description": "Expired peer-issued TCT MUST be rejected regardless of signature validity.",
   "tags": [
     "failure",

--- a/schemas/conformance/tct-003-signature-invalid.json
+++ b/schemas/conformance/tct-003-signature-invalid.json
@@ -1,5 +1,9 @@
 {
   "id": "tct-003",
+  "rfc": "RFC-AITP-0005",
+  "status": "core",
+  "required_for_v0_1": true,
+  "feature": null,
   "description": "TCT signature does not validate under the issuing peer's resolved public key (e.g. tampered grant, swapped audience, or wrong key). Receivers MUST reject with TCT_SIGNATURE_INVALID (RFC-AITP-0005). The check is local.",
   "tags": [
     "security",

--- a/schemas/conformance/tct-004-revoked.json
+++ b/schemas/conformance/tct-004-revoked.json
@@ -1,5 +1,9 @@
 {
   "id": "tct-004",
+  "rfc": "RFC-AITP-0008",
+  "status": "core",
+  "required_for_v0_1": true,
+  "feature": null,
   "description": "TCT signature is valid and not expired, but its `jti` appears in the issuing peer's revocation list. Receivers MUST reject with TCT_REVOKED (RFC-AITP-0008). Per the per-issuing-peer model, only the originating issuer's deny list applies.",
   "tags": [
     "security",

--- a/schemas/conformance/tct-005-expires-after-manifest-rejected.json
+++ b/schemas/conformance/tct-005-expires-after-manifest-rejected.json
@@ -1,5 +1,9 @@
 {
   "id": "tct-005",
+  "rfc": "RFC-AITP-0005",
+  "status": "core",
+  "required_for_v0_1": true,
+  "feature": null,
   "description": "A TCT whose `expires_at` is after the issuing peer's Manifest `expires_at` MUST be rejected (RFC-AITP-0004 §4.3; alpha.5 P6). The issuing peer MUST NOT mint such a TCT in the first place; verifiers MAY assert the bound at verification time. The verifier here treats the TCT body as already past expiry relative to a reference clock that postdates the issuing Manifest, mirroring the runtime check.",
   "tags": [
     "failure",

--- a/schemas/conformance/tct-006-pop-challenge-response.json
+++ b/schemas/conformance/tct-006-pop-challenge-response.json
@@ -1,5 +1,9 @@
 {
   "id": "tct-006",
+  "rfc": "RFC-AITP-0005",
+  "status": "core",
+  "required_for_v0_1": true,
+  "feature": null,
   "description": "Happy-path downstream PoP exchange (RFC-AITP-0005 §6.1, §6.2). A consuming peer (agentA) issues a `pop_challenge` for a TCT it holds against subject agentB; agentB returns a `pop_response` whose `nonce_echo` matches the challenge nonce and whose `pop_signature` is `sign(agentB_priv, sha256(base64url_decode(nonce)))`. The runner MUST execute both steps and assert that the verifier (agentA) accepts the response. This fixture proves the implementation can produce AND verify a downstream PoP exchange end-to-end (the §6.2 conformance-note requirement). Whether an implementation *enforces* PoP for every grant is deployment-configurable; the *capability* tested here is mandatory.",
   "tags": [
     "success",

--- a/schemas/json/aitp-conformance-fixture.schema.json
+++ b/schemas/json/aitp-conformance-fixture.schema.json
@@ -1,0 +1,69 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://aitp.dev/schema/v0.1/aitp-conformance-fixture.schema.json",
+  "title": "AITP Conformance Fixture (metadata block)",
+  "description": "Validates the leading metadata block every fixture under schemas/conformance/ MUST carry. Scenario content (`input`, `expected`, `tags`, etc.) is fixture-shape-specific and is not validated here; this schema enforces only the metadata contract that a v0.1 conformance runner relies on.",
+  "type": "object",
+  "required": [
+    "id",
+    "rfc",
+    "status",
+    "required_for_v0_1",
+    "feature"
+  ],
+  "properties": {
+    "id": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Fixture id (e.g. mh-success-001, del-004-multihop-rejected-v01)."
+    },
+    "rfc": {
+      "type": "string",
+      "pattern": "^RFC-AITP-[0-9]{4}$",
+      "description": "Most-specific RFC the fixture exercises."
+    },
+    "status": {
+      "enum": ["core", "draft", "extension", "reserved"],
+      "description": "Conformance tier. See schemas/conformance/README.md."
+    },
+    "required_for_v0_1": {
+      "type": "boolean",
+      "description": "Whether a v0.1 implementation MUST pass this fixture. Always false when status != 'core'."
+    },
+    "feature": {
+      "type": ["string", "null"],
+      "description": "Opt-in feature flag for non-core fixtures (null for core)."
+    },
+    "description": { "type": "string" },
+    "tags": {
+      "type": "array",
+      "items": { "type": "string" }
+    },
+    "input": { "type": "object" },
+    "expected": { "type": "object" }
+  },
+  "allOf": [
+    {
+      "if": { "properties": { "status": { "const": "core" } } },
+      "then": {
+        "properties": {
+          "required_for_v0_1": { "const": true },
+          "feature": { "const": null }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "status": { "enum": ["draft", "extension", "reserved"] }
+        }
+      },
+      "then": {
+        "properties": {
+          "required_for_v0_1": { "const": false }
+        }
+      }
+    }
+  ],
+  "additionalProperties": true
+}

--- a/scripts/validate-json.sh
+++ b/scripts/validate-json.sh
@@ -14,6 +14,7 @@ DELEGATION_SCHEMA="${PROJECT_ROOT}/schemas/json/aitp-delegation.schema.json"
 TRUST_ANCHORS_SCHEMA="${PROJECT_ROOT}/schemas/json/aitp-trust-anchors.schema.json"
 MANIFEST_SCHEMA="${PROJECT_ROOT}/schemas/json/aitp-manifest.schema.json"
 REVOCATION_LIST_SCHEMA="${PROJECT_ROOT}/schemas/json/aitp-revocation-list.schema.json"
+FIXTURE_META_SCHEMA="${PROJECT_ROOT}/schemas/json/aitp-conformance-fixture.schema.json"
 NON_NORMATIVE_DIR="${PROJECT_ROOT}/examples/non-normative"
 
 CONFORMANCE_DIR="${PROJECT_ROOT}/schemas/conformance"
@@ -49,18 +50,27 @@ syntax_check() {
     fi
 }
 
-# ── Conformance fixtures: syntax-only ────────────────────────────────────────
+# ── Conformance fixtures: syntax check + metadata block schema ──────────────
+# Fixture scenario content (input/expected) is fixture-shape-specific; we
+# syntax-check that, then validate the leading metadata block against
+# aitp-conformance-fixture.schema.json so a v0.1 conformance runner can
+# trust id / rfc / status / required_for_v0_1 / feature.
 if [ -d "$CONFORMANCE_DIR" ]; then
     echo "── Conformance fixtures (${CONFORMANCE_DIR}) ──"
     for f in "${CONFORMANCE_DIR}"/*.json; do
         [ -f "$f" ] || continue
         TOTAL=$((TOTAL + 1))
         echo "  $(basename "$f")"
-        if syntax_check "$f"; then
-            VALIDATED=$((VALIDATED + 1))
-            echo "    ✓ Valid JSON"
-        else
+        if ! syntax_check "$f"; then
             echo "    ✗ Invalid JSON"
+            exit 1
+        fi
+        if ajv validate -s "${FIXTURE_META_SCHEMA}" -d "${f}" --spec=draft2020 --strict=false -c ajv-formats >/dev/null 2>&1; then
+            VALIDATED=$((VALIDATED + 1))
+            echo "    ✓ Valid JSON + metadata block conforms"
+        else
+            echo "    ✗ Metadata block fails aitp-conformance-fixture schema"
+            ajv validate -s "${FIXTURE_META_SCHEMA}" -d "${f}" --spec=draft2020 --strict=false -c ajv-formats || true
             exit 1
         fi
     done


### PR DESCRIPTION
## Summary

Aligns the published AITP RFCs with reference-library reality, tightens four security surfaces, and introduces machine-readable conformance metadata so v0.1 conformance runners correctly skip post-v0.1 fixtures.

11 changes across 4 themes — all P0–P3 items landed in one pass to keep the spec/library deltas reviewable as a single coherent surface.

---

## Spec / library reconciliation

- **RFC-AITP-0004 §8.1** — non-normative shortened-renewal extension. Defines wire format (`POST /aitp/handshake/renew`, current TCT + PoP), discovery via `extensions["rfc-aitp-0005.renew_uri"]`, and the rule that an expired TCT MUST NOT bootstrap a shortened renewal. Reserves **RFC-AITP-0013 (Planned)** for eventual standardization. Fixes the documented prohibition that the reference library was already violating.
- **RFC-AITP-0010** — top-of-file conformance-scope statement. The MUST-level normative text in this RFC applies *only* to implementations that opt into draft conformance; v0.1 implementations that ignore Session Trust Bundles are conformant. v0.1 runners MUST treat the `bundle-*` fixture set as SKIP.
- **New conformance fixture `del-004-multihop-rejected-v01`** — proves a v0.1 implementation rejects any delegation token with a non-empty `chain` field via `DELEGATION_MULTIHOP_NOT_SUPPORTED` *as a structural early check*, before any per-hop signature work. Closes the gap where `del-mh-*` only tested multi-hop *acceptance*, never v0.1 *rejection*.

## Security tightenings

- **RFC-AITP-0008 §3.3 (new)** — revocation lookup ordering MUST. All network-adjacent revocation lookups (HTTP, DNS, cache writes) MUST be deferred until *after* signature, key-binding, audience, and expiry verification. Closes the attacker-chosen-network-fetch / cache-pollution / side-channel-disclosure class of bugs that arises when an attacker can set `tct.issuer` to any AID before the signature is checked.
- **RFC-AITP-0007 §3.2 (new)** — `soft_fail` MUST behave as `fail_closed` when no trust basis exists for an issuer (no cached key, no pinned key, no deployment-local trust context). Peer-Manifest key resolution is `fail_closed` regardless of mode — no safe subset for unverified identity. Prevents an attacker who blocks all issuer-key sources from being granted the safe subset by default.
- **RFC-AITP-0002 §3.2 (new)** — pinned-key key-possession-only verification forbidden as a production default. AID construction is deterministic from the public key, so possession alone proves nothing about trust. Production code paths MUST consult a configured `pinned_keys` store; an `unsafe_no_trust_store` development mode is permitted only with explicit opt-in and a high-severity warning.

## Conformance metadata + CI enforcement

- **Every fixture under `schemas/conformance/`** now carries a metadata block: `id`, `rfc`, `status` (`core | draft | extension | reserved`), `required_for_v0_1`, `feature`. Bundle / multi-hop fixtures tagged `status: "draft"` with feature flags `experimental-session-bundle` / `experimental-multihop-delegation`. v0.1 core fixtures tagged `status: "core"`.
- **New `schemas/json/aitp-conformance-fixture.schema.json`** enforces the metadata block, including conditional invariants: `status: core` ⇒ `required_for_v0_1: true` and `feature: null`; `status: draft|extension|reserved` ⇒ `required_for_v0_1: false`.
- **`scripts/validate-json.sh`** now validates every fixture against the metadata schema in addition to syntax. The existing `.github/workflows/ci.yml` invokes this script unchanged, so the new check runs on every PR. **55/55 JSON files pass**, **10/10 JSON Schemas valid**.

## Registries

- **`registries/error-codes.md`** — added `TCT_EXPIRES_AFTER_MANIFEST` (TCT expires beyond issuer Manifest expiry) and `INCOMPATIBLE_IDENTITY_TYPE` (peer's identity type not in `accepted_identity_types`). Added `spec_status` (`core | draft`) column to every table so post-v0.1 codes are machine-distinguishable.
- **New `registries/extension-keys.md`** — pins the four AITP-defined Manifest extension keys (`rfc-aitp-0005.verify_uri`, `rfc-aitp-0005.renew_uri`, `rfc-aitp-0006.delegation_verify_uri`, `rfc-aitp-0008.revocation_list_uri`) so independent implementations don't fork the strings. Indexed in `registries/README.md`.

## Process + operational guidance

- **`governance/RFC-PROCESS.md`** — strengthened the KAT requirement. Preimages MUST be published as **hex bytes** (the `sha256(base64url_decode(x))` decode-before-hash convention is non-obvious from text alone and has caused two interop bugs). Default signing keypair pinned to `kat-keypair-001`. Explicit non-merge gate for PRs introducing new signing inputs without a KAT vector.
- **`docs/operational-guidance.md`** — new "Shortened renewal (experimental)" section. Covers when to enable the opt-in extension, Manifest discovery, the **24h / 8-renewal full-bind ceiling** so long-lived sessions periodically re-bind identity end-to-end, and the failure-mode fallback to full handshake.

---

## Test plan

- [x] `make validate` — 55/55 JSON files pass (10 schemas + 45 fixtures + KAT vectors + signed examples).
- [x] `make release RELEASE_VERSION=ci-dryrun` — archive builds clean, no excluded paths leak.
- [x] Every fixture validates against the new `aitp-conformance-fixture.schema.json`.
- [x] Conditional schema invariant verified: a `status: "core"` fixture with `required_for_v0_1: false` would be rejected by ajv (manually toggled and reverted on `del-001` during development).
- [ ] **Reviewer**: spot-check the 6 bundle / del-mh fixtures that received cosmetic JSON re-formatting (compact arrays expanded to multi-line) — content is byte-equivalent, only whitespace shifted.
- [ ] **Reviewer**: confirm the metadata-block enforcement rules in `schemas/conformance/README.md` match the runtime enforcement intent expected by downstream conformance runners (`aitp-rs`, etc.).