### PR TITLE
ci: add notify-website workflow to sync docs changes

### DIFF
--- a/.github/workflows/notify-website.yml
+++ b/.github/workflows/notify-website.yml
@@ -1,0 +1,20 @@
+name: Notify Website of Doc Changes
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'docs/**'
+      - 'rfcs/**'
+      - 'registries/**'
+      - 'schemas/**'
+
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.WEBSITE_SYNC_TOKEN }}
+          repository: agentidentitytrustprotocol/website
+          event-type: docs-updated


### PR DESCRIPTION
## Summary

Adds a `notify-website` GitHub Actions workflow that keeps the published documentation site in sync with this repository.

On a push to `main` that touches documentation-bearing paths, the workflow dispatches a `docs-updated` `repository_dispatch` event to the `agentidentitytrustprotocol/website` repo, allowing the site to rebuild automatically.

## Details

- **Trigger:** `push` to `main`, filtered to the paths below
- **Watched paths:**
  - `docs/**`
  - `rfcs/**`
  - `registries/**`
  - `schemas/**` — the repo's normative JSON Schemas are surfaced on the site
- **Action:** `peter-evans/repository-dispatch@v3` sending `event-type: docs-updated` to `agentidentitytrustprotocol/website`

## Required configuration

For the workflow to dispatch successfully, two things must exist on the GitHub side:

1. A `WEBSITE_SYNC_TOKEN` repository (or org) secret with permission to dispatch events to the `website` repo.
2. The `agentidentitytrustprotocol/website` repo with a workflow listening for `repository_dispatch` of type `docs-updated`.