### PR TITLE
ci: spec propagation + App-token notifies + Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  # The spec repo ships no package manifest — only GitHub Actions to keep fresh.
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      actions:
+        patterns: ["*"]

--- a/.github/workflows/notify-spec-consumers.yml
+++ b/.github/workflows/notify-spec-consumers.yml
@@ -1,0 +1,45 @@
+name: Notify spec consumers
+
+# On a conformance-relevant change to the spec, dispatch `spec-released {sha}`
+# to every repo that pins the spec by git SHA. Today that is aitp-rs (it pins
+# the spec in tests/schemas/SPEC_VERSION). aitp-verifier-py tracks the spec on
+# `main` (floating), so it is intentionally not notified.
+#
+# The consumer's bump-spec.yml calls aitp-ci/bump-spec-ref, which opens a HELD
+# PR (never auto-merged): adopting a new spec is a deliberate review decision,
+# and the PR's own conformance CI runs against the new fixtures.
+#
+# Auth: the aitp-deps-bot GitHub App (org secrets AITP_BOT_APP_ID /
+# AITP_BOT_PRIVATE_KEY) — a short-lived installation token, no PAT.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'schemas/**'
+      - 'examples/**'
+      - 'rfcs/**'
+      - 'registries/**'
+      - 'docs/**'
+  workflow_dispatch:
+
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Mint GitHub App token (scoped to aitp-rs)
+        id: app
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.AITP_BOT_APP_ID }}
+          private-key: ${{ secrets.AITP_BOT_PRIVATE_KEY }}
+          owner: agentidentitytrustprotocol
+          repositories: aitp-rs
+
+      - name: Dispatch spec-released to aitp-rs
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ steps.app.outputs.token }}
+          repository: agentidentitytrustprotocol/aitp-rs
+          event-type: spec-released
+          client-payload: '{"sha": "${{ github.sha }}"}'

--- a/.github/workflows/notify-website.yml
+++ b/.github/workflows/notify-website.yml
@@ -14,8 +14,17 @@ jobs:
   notify:
     runs-on: ubuntu-latest
     steps:
+      - name: Mint GitHub App token (scoped to aitp-website)
+        id: app
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.AITP_BOT_APP_ID }}
+          private-key: ${{ secrets.AITP_BOT_PRIVATE_KEY }}
+          owner: agentidentitytrustprotocol
+          repositories: aitp-website
+
       - uses: peter-evans/repository-dispatch@v3
         with:
-          token: ${{ secrets.AITP_WEBSITE_SYNC_TOKEN }}
+          token: ${{ steps.app.outputs.token }}
           repository: agentidentitytrustprotocol/aitp-website
           event-type: docs-updated


### PR DESCRIPTION
Wires the spec repo into the org CI/CD model (aitp-ci@v1):

- **notify-spec-consumers** — on a conformance-relevant push (schemas / examples / rfcs / registries / docs), dispatch `spec-released {sha}` to the SHA-pinner (aitp-rs). aitp-verifier-py floats the spec on `main`, so it is intentionally not notified.
- **notify-website** — mint a short-lived `aitp-deps-bot` App token instead of the `AITP_WEBSITE_SYNC_TOKEN` PAT.
- **dependabot** — add `github-actions` updates.