### PR TITLE
ci(dependabot): switch to monthly to cut PR volume

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,7 @@ updates:
   - package-ecosystem: github-actions
     directory: /
     schedule:
-      interval: weekly
+      interval: monthly
     groups:
       actions:
         patterns: ["*"]


### PR DESCRIPTION
Reduce Dependabot PR frequency: switch schedule interval from weekly to **monthly** across all ecosystems (and drop the weekly-only `day:` field). Grouping is unchanged. Config-only.